### PR TITLE
Safer time parsing

### DIFF
--- a/lib/whois/parsers/base.rb
+++ b/lib/whois/parsers/base.rb
@@ -163,7 +163,18 @@ module Whois
         self.class.property_state?(property, Parser::PROPERTY_STATE_SUPPORTED)
       end
 
-
+      # Parses a timestamp, returning nil for invalid input
+      #
+      # @param  [String] timestamp The timestamp to parse
+      # @return [Nil] if the timestamp can't be parsed
+      # @return [Time]
+      #
+      def self.parse_time(timestamp)
+        return unless timestamp.is_a?(String) && !timestamp.empty?
+        Time.parse(timestamp).change(usec: 0)
+      rescue ArgumentError
+        nil
+      end
 
       # @return [Whois::Record::Part] The part referenced by this parser.
       attr_reader :part
@@ -371,6 +382,10 @@ module Whois
         else
           value
         end
+      end
+
+      def parse_time(timestamp)
+        self.class.parse_time(timestamp)
       end
 
       def handle_property(property, *args)

--- a/lib/whois/parsers/base_afilias.rb
+++ b/lib/whois/parsers/base_afilias.rb
@@ -52,19 +52,19 @@ module Whois
 
       property_supported :created_on do
         node("Created On") do |value|
-          Time.parse(value)
+          parse_time(value)
         end
       end
 
       property_supported :updated_on do
         node("Last Updated On") do |value|
-          Time.parse(value)
+          parse_time(value)
         end
       end
 
       property_supported :expires_on do
         node("Expiration Date") do |value|
-          Time.parse(value)
+          parse_time(value)
         end
       end
 

--- a/lib/whois/parsers/base_afilias2.rb
+++ b/lib/whois/parsers/base_afilias2.rb
@@ -52,19 +52,19 @@ module Whois
 
       property_supported :created_on do
         node("Creation Date") do |value|
-          Time.parse(value)
+          parse_time(value)
         end
       end
 
       property_supported :updated_on do
         node("Updated Date") do |value|
-          Time.parse(value)
+          parse_time(value)
         end
       end
 
       property_supported :expires_on do
         node("Registry Expiry Date") do |value|
-          Time.parse(value)
+          parse_time(value)
         end
       end
 

--- a/lib/whois/parsers/base_cocca.rb
+++ b/lib/whois/parsers/base_cocca.rb
@@ -55,19 +55,19 @@ module Whois
 
       property_supported :created_on do
         if content_for_scanner =~ /Created:\s+(.+?)\n/
-          Time.parse($1)
+          parse_time($1)
         end
       end
 
       property_supported :updated_on do
         if content_for_scanner =~ /Modified:\s+(.+?)\n/
-          Time.parse($1)
+          parse_time($1)
         end
       end
 
       property_supported :expires_on do
         if content_for_scanner =~ /Expires:\s+(.+?)\n/
-          Time.parse($1)
+          parse_time($1)
         end
       end
 

--- a/lib/whois/parsers/base_cocca2.rb
+++ b/lib/whois/parsers/base_cocca2.rb
@@ -85,13 +85,6 @@ module Whois
         end
       end
 
-
-      private
-
-      def parse_time(value)
-        Time.parse(value).change(usec: 0)
-      end
-
     end
 
 end

--- a/lib/whois/parsers/base_cocca2.rb
+++ b/lib/whois/parsers/base_cocca2.rb
@@ -60,7 +60,7 @@ module Whois
       end
 
       property_supported :updated_on do
-        node("Updated Date") { |value| parse_time(value) unless value.empty? }
+        node("Updated Date") { |value| parse_time(value) }
       end
 
       property_supported :expires_on do

--- a/lib/whois/parsers/base_icann_compliant.rb
+++ b/lib/whois/parsers/base_icann_compliant.rb
@@ -133,10 +133,6 @@ module Whois
 
       private
 
-      def parse_time(value)
-        Time.parse(value)
-      end
-
       def value_for_phone_property(element, property)
         [
           value_for_property(element, "#{property}"),

--- a/lib/whois/parsers/base_icb.rb
+++ b/lib/whois/parsers/base_icb.rb
@@ -52,7 +52,7 @@ module Whois
 
       property_supported :expires_on do
         if content_for_scanner =~ /Expiry : (.+?)\n/
-          Time.parse($1)
+          parse_time($1)
         end
       end
 

--- a/lib/whois/parsers/base_iisse.rb
+++ b/lib/whois/parsers/base_iisse.rb
@@ -53,15 +53,15 @@ module Whois
 
 
       property_supported :created_on do
-        node("created") { |value| Time.parse(value) }
+        node("created") { |value| parse_time(value) }
       end
 
       property_supported :expires_on do
-        node("expires") { |value| Time.parse(value) }
+        node("expires") { |value| parse_time(value) }
       end
 
       property_supported :updated_on do
-        node("modified") { |value| Time.parse(value) unless value == "-" }
+        node("modified") { |value| parse_time(value) unless value == "-" }
       end
 
 

--- a/lib/whois/parsers/base_iisse.rb
+++ b/lib/whois/parsers/base_iisse.rb
@@ -61,7 +61,7 @@ module Whois
       end
 
       property_supported :updated_on do
-        node("modified") { |value| parse_time(value) unless value == "-" }
+        node("modified") { |value| parse_time(value) }
       end
 
 

--- a/lib/whois/parsers/base_nic_fr.rb
+++ b/lib/whois/parsers/base_nic_fr.rb
@@ -53,14 +53,14 @@ module Whois
       property_supported :created_on do
         if content_for_scanner =~ /created:\s+(.+)\n/
           d, m, y = $1.split("/")
-          Time.parse("#{y}-#{m}-#{d}")
+          parse_time("#{y}-#{m}-#{d}")
         end
       end
 
       property_supported :updated_on do
         if content_for_scanner =~ /last-update:\s+(.+)\n/
           d, m, y = $1.split("/")
-          Time.parse("#{y}-#{m}-#{d}")
+          parse_time("#{y}-#{m}-#{d}")
         end
       end
 

--- a/lib/whois/parsers/base_shared2.rb
+++ b/lib/whois/parsers/base_shared2.rb
@@ -52,15 +52,15 @@ module Whois
 
 
       property_supported :created_on do
-        node("Domain Registration Date") { |value| Time.parse(value) }
+        node("Domain Registration Date") { |value| parse_time(value) }
       end
 
       property_supported :updated_on do
-        node("Domain Last Updated Date") { |value| Time.parse(value) }
+        node("Domain Last Updated Date") { |value| parse_time(value) }
       end
 
       property_supported :expires_on do
-        node("Domain Expiration Date") { |value| Time.parse(value) }
+        node("Domain Expiration Date") { |value| parse_time(value) }
       end
 
 

--- a/lib/whois/parsers/base_shared3.rb
+++ b/lib/whois/parsers/base_shared3.rb
@@ -55,15 +55,15 @@ module Whois
 
 
       property_supported :created_on do
-        node("created date") { |value| Time.parse(value) }
+        node("created date") { |value| parse_time(value) }
       end
 
       property_supported :updated_on do
-        node("updated date") { |value| Time.parse(value) }
+        node("updated date") { |value| parse_time(value) }
       end
 
       property_supported :expires_on do
-        node("expiration date") { |value| Time.parse(value) }
+        node("expiration date") { |value| parse_time(value) }
       end
 
 

--- a/lib/whois/parsers/base_verisign.rb
+++ b/lib/whois/parsers/base_verisign.rb
@@ -53,15 +53,15 @@ module Whois
 
 
       property_supported :created_on do
-        node("Creation Date") { |value| Time.parse(value) }
+        node("Creation Date") { |value| parse_time(value) }
       end
 
       property_supported :updated_on do
-        node("Updated Date") { |value| Time.parse(value) }
+        node("Updated Date") { |value| parse_time(value) }
       end
 
       property_supported :expires_on do
-        node("Registry Expiry Date") { |value| Time.parse(value) }
+        node("Registry Expiry Date") { |value| parse_time(value) }
       end
 
 

--- a/lib/whois/parsers/base_whoisd.rb
+++ b/lib/whois/parsers/base_whoisd.rb
@@ -57,15 +57,15 @@ module Whois
 
 
       property_supported :created_on do
-        node('registered') { |string| Time.parse(string) }
+        node('registered') { |string| parse_time(string) }
       end
 
       property_supported :updated_on do
-        node('changed') { |string| Time.parse(string) }
+        node('changed') { |string| parse_time(string) }
       end
 
       property_supported :expires_on do
-        node('expire') { |string| Time.parse(string) }
+        node('expire') { |string| parse_time(string) }
       end
 
 
@@ -134,7 +134,7 @@ module Whois
               :country_code   => hash['country'],
               :phone          => hash['phone'],
               :email          => hash['e-mail'],
-              :created_on     => Time.parse(hash['created'])
+              :created_on     => parse_time(hash['created'])
           )
         end
       end

--- a/lib/whois/parsers/whois.aero.rb
+++ b/lib/whois/parsers/whois.aero.rb
@@ -36,13 +36,13 @@ module Whois
 
       property_supported :updated_on do
         node("Updated On") do |value|
-          Time.parse(value)
+          parse_time(value)
         end
       end
 
       property_supported :expires_on do
         node("Expires On") do |value|
-          Time.parse(value)
+          parse_time(value)
         end
       end
 

--- a/lib/whois/parsers/whois.amnic.net.rb
+++ b/lib/whois/parsers/whois.amnic.net.rb
@@ -48,19 +48,19 @@ module Whois
 
       property_supported :created_on do
         if content_for_scanner =~ /\s+Registered:\s+(.+)\n/
-          Time.parse($1)
+          parse_time($1)
         end
       end
 
       property_supported :updated_on do
         if content_for_scanner =~ /\s+Last modified:\s+(.+)\n/
-          Time.parse($1)
+          parse_time($1)
         end
       end
 
       property_supported :expires_on do
         if content_for_scanner =~ /\s+Expires:\s+(.+)\n/
-          Time.parse($1)
+          parse_time($1)
         end
       end
 

--- a/lib/whois/parsers/whois.ati.tn.rb
+++ b/lib/whois/parsers/whois.ati.tn.rb
@@ -55,7 +55,7 @@ module Whois
 
 
       property_supported :created_on do
-        node("Acivated") { |value| Time.parse(value) }
+        node("Acivated") { |value| parse_time(value) }
       end
 
       property_not_supported :updated_on
@@ -104,8 +104,8 @@ module Whois
             phone:        node("#{element} Tel"),
             fax:          node("#{element} Fax"),
             email:        node("#{element} Email"),
-            created_on:   node("#{element} Created") { |value| Time.parse(value) },
-            updated_on:   node("#{element} Updated") { |value| Time.parse(value) if value != "None" }
+            created_on:   node("#{element} Created") { |value| parse_time(value) },
+            updated_on:   node("#{element} Updated") { |value| parse_time(value) if value != "None" }
           )
         end
       end

--- a/lib/whois/parsers/whois.ati.tn.rb
+++ b/lib/whois/parsers/whois.ati.tn.rb
@@ -105,7 +105,7 @@ module Whois
             fax:          node("#{element} Fax"),
             email:        node("#{element} Email"),
             created_on:   node("#{element} Created") { |value| parse_time(value) },
-            updated_on:   node("#{element} Updated") { |value| parse_time(value) if value != "None" }
+            updated_on:   node("#{element} Updated") { |value| parse_time(value) }
           )
         end
       end

--- a/lib/whois/parsers/whois.audns.net.au.rb
+++ b/lib/whois/parsers/whois.audns.net.au.rb
@@ -56,7 +56,7 @@ module Whois
       property_not_supported :created_on
 
       property_supported :updated_on do
-        node("Last Modified") { |value| Time.parse(value) }
+        node("Last Modified") { |value| parse_time(value) }
       end
 
       property_not_supported :expires_on

--- a/lib/whois/parsers/whois.ax.rb
+++ b/lib/whois/parsers/whois.ax.rb
@@ -43,7 +43,7 @@ module Whois
 
       property_supported :created_on do
         if content_for_scanner =~ /Created:\s+(.+)\n/
-          Time.parse($1)
+          parse_time($1)
         end
       end
 

--- a/lib/whois/parsers/whois.bnnic.bn.rb
+++ b/lib/whois/parsers/whois.bnnic.bn.rb
@@ -43,19 +43,19 @@ module Whois
 
       property_supported :created_on do
         if content_for_scanner =~ /Creation Date:\s+(.+)\n/
-          Time.parse($1)
+          parse_time($1)
         end
       end
 
       property_supported :updated_on do
         if content_for_scanner =~ /Modified Date:\s+(.+)\n/
-          Time.parse($1)
+          parse_time($1)
         end
       end
 
       property_supported :expires_on do
         if content_for_scanner =~ /Expiration Date:\s+(.+)\n/
-          Time.parse($1)
+          parse_time($1)
         end
       end
 

--- a/lib/whois/parsers/whois.cat.rb
+++ b/lib/whois/parsers/whois.cat.rb
@@ -41,19 +41,19 @@ module Whois
 
       property_supported :created_on do
         if content_for_scanner =~ /Created On:\s+(.*)\n/
-          Time.parse($1)
+          parse_time($1)
         end
       end
 
       property_supported :updated_on do
         if content_for_scanner =~ /Last Updated On:\s+(.*)\n/
-          Time.parse($1)
+          parse_time($1)
         end
       end
 
       property_supported :expires_on do
         if content_for_scanner =~ /Expiration Date:\s+(.*)\n/
-          Time.parse($1)
+          parse_time($1)
         end
       end
 

--- a/lib/whois/parsers/whois.cctld.by.rb
+++ b/lib/whois/parsers/whois.cctld.by.rb
@@ -54,15 +54,15 @@ module Whois
 
 
       property_supported :created_on do
-        node("Creation Date") { |value| Time.parse(value) }
+        node("Creation Date") { |value| parse_time(value) }
       end
 
       property_supported :updated_on do
-        node("Updated Date") { |value| Time.parse(value) }
+        node("Updated Date") { |value| parse_time(value) }
       end
 
       property_supported :expires_on do
-        node("Expiration Date") { |value| Time.parse(value) }
+        node("Expiration Date") { |value| parse_time(value) }
       end
 
 

--- a/lib/whois/parsers/whois.cctld.uz.rb
+++ b/lib/whois/parsers/whois.cctld.uz.rb
@@ -60,7 +60,7 @@ module Whois
 
       property_supported :expires_on do
         if content_for_scanner =~ /Expiration Date:\s+(.+)\n/
-          parse_time($1) unless $1 == '-'
+          parse_time($1)
         end
       end
 

--- a/lib/whois/parsers/whois.cctld.uz.rb
+++ b/lib/whois/parsers/whois.cctld.uz.rb
@@ -48,19 +48,19 @@ module Whois
 
       property_supported :created_on do
         if content_for_scanner =~ /Creation Date:(.+)\n/
-          Time.parse($1)
+          parse_time($1)
         end
       end
 
       property_supported :updated_on do
         if content_for_scanner =~ /Updated Date:(.+)\n/
-          Time.parse($1)
+          parse_time($1)
         end
       end
 
       property_supported :expires_on do
         if content_for_scanner =~ /Expiration Date:\s+(.+)\n/
-          Time.parse($1) unless $1 == '-'
+          parse_time($1) unless $1 == '-'
         end
       end
 

--- a/lib/whois/parsers/whois.centralnic.com.rb
+++ b/lib/whois/parsers/whois.centralnic.com.rb
@@ -53,18 +53,18 @@ module Whois
 
 
       property_supported :created_on do
-        node("Created On")  { |str| Time.parse(str) } ||
-        node("Creation Date") { |str| Time.parse(str) }
+        node("Created On")  { |str| parse_time(str) } ||
+        node("Creation Date") { |str| parse_time(str) }
       end
 
       property_supported :updated_on do
-        node("Last Updated On") { |str| Time.parse(str) } ||
-        node("Updated Date") { |str| Time.parse(str) }
+        node("Last Updated On") { |str| parse_time(str) } ||
+        node("Updated Date") { |str| parse_time(str) }
       end
 
       property_supported :expires_on do
-        node("Expiration Date") { |str| Time.parse(str) } ||
-        node("Registry Expiry Date") { |str| Time.parse(str) }
+        node("Expiration Date") { |str| parse_time(str) } ||
+        node("Registry Expiry Date") { |str| parse_time(str) }
       end
 
 

--- a/lib/whois/parsers/whois.cira.ca.rb
+++ b/lib/whois/parsers/whois.cira.ca.rb
@@ -72,15 +72,15 @@ module Whois
 
 
       property_supported :created_on do
-        node("Creation date") { |str| Time.parse(str) }
+        node("Creation date") { |str| parse_time(str) }
       end
 
       property_supported :updated_on do
-        node("Updated date") { |str| Time.parse(str) }
+        node("Updated date") { |str| parse_time(str) }
       end
 
       property_supported :expires_on do
-        node("Expiry date") { |str| Time.parse(str) }
+        node("Expiry date") { |str| parse_time(str) }
       end
 
 

--- a/lib/whois/parsers/whois.cnnic.cn.rb
+++ b/lib/whois/parsers/whois.cnnic.cn.rb
@@ -47,13 +47,13 @@ module Whois
 
 
       property_supported :created_on do
-        node("Registration Time") { |value| Time.parse(value) }
+        node("Registration Time") { |value| parse_time(value) }
       end
 
       property_not_supported :updated_on
 
       property_supported :expires_on do
-        node("Expiration Time") { |value| Time.parse(value) }
+        node("Expiration Time") { |value| parse_time(value) }
       end
 
 

--- a/lib/whois/parsers/whois.co.ca.rb
+++ b/lib/whois/parsers/whois.co.ca.rb
@@ -43,7 +43,7 @@ module Whois
 
       property_supported :created_on do
         if content_for_scanner =~ /date_approved:\s+(.+)\n/
-          Time.parse($1)
+          parse_time($1)
         end
       end
 
@@ -51,7 +51,7 @@ module Whois
 
       property_supported :expires_on do
         if content_for_scanner =~ /date_renewal:\s+(.+)\n/
-          Time.parse($1)
+          parse_time($1)
         end
       end
 

--- a/lib/whois/parsers/whois.co.pl.rb
+++ b/lib/whois/parsers/whois.co.pl.rb
@@ -53,7 +53,7 @@ module Whois
 
       property_supported :updated_on do
         if content_for_scanner =~ /changed:\s+(.+?)\n/
-          Time.parse($1)
+          parse_time($1)
         end
       end
 

--- a/lib/whois/parsers/whois.co.ug.rb
+++ b/lib/whois/parsers/whois.co.ug.rb
@@ -53,7 +53,7 @@ module Whois
 
       property_supported :created_on do
         if content_for_scanner =~ /Registered:\s+(.+)$/
-          Time.parse($1)
+          parse_time($1)
         end
       end
 
@@ -65,7 +65,7 @@ module Whois
 
       property_supported :expires_on do
         if content_for_scanner =~ /Expiry:\s(.+)$/
-          Time.parse($1)
+          parse_time($1)
         end
       end
 

--- a/lib/whois/parsers/whois.comlaude.com.rb
+++ b/lib/whois/parsers/whois.comlaude.com.rb
@@ -34,7 +34,7 @@ module Whois
 
       property_supported :created_on do
         if content_for_scanner =~ /Registered: (.+)\n/
-          Time.parse($1)
+          parse_time($1)
         end
       end
 
@@ -42,7 +42,7 @@ module Whois
 
       property_supported :expires_on do
         if content_for_scanner =~ /Expires: (.+)\n/
-          Time.parse($1)
+          parse_time($1)
         end
       end
 

--- a/lib/whois/parsers/whois.denic.de.rb
+++ b/lib/whois/parsers/whois.denic.de.rb
@@ -71,7 +71,7 @@ module Whois
       property_not_supported :created_on
 
       property_supported :updated_on do
-        node("Changed") { |value| Time.parse(value) }
+        node("Changed") { |value| parse_time(value) }
       end
 
       property_not_supported :expires_on

--- a/lib/whois/parsers/whois.dk-hostmaster.dk.rb
+++ b/lib/whois/parsers/whois.dk-hostmaster.dk.rb
@@ -55,7 +55,7 @@ module Whois
 
       property_supported :created_on do
         if content_for_scanner =~ /Registered:\s+(.*)\n/
-          Time.parse($1)
+          parse_time($1)
         end
       end
 
@@ -63,7 +63,7 @@ module Whois
 
       property_supported :expires_on do
         if content_for_scanner =~ /Expires:\s+(.*)\n/
-          Time.parse($1)
+          parse_time($1)
         end
       end
 

--- a/lib/whois/parsers/whois.dns.be.rb
+++ b/lib/whois/parsers/whois.dns.be.rb
@@ -61,7 +61,7 @@ module Whois
 
       property_supported :created_on do
         if content_for_scanner =~ /Registered:\s+(.+)\n/
-          Time.parse($1)
+          parse_time($1)
         end
       end
 

--- a/lib/whois/parsers/whois.dns.hr.rb
+++ b/lib/whois/parsers/whois.dns.hr.rb
@@ -57,7 +57,7 @@ module Whois
       property_not_supported :updated_on
 
       property_supported :expires_on do
-        node("expires") { |value| Time.parse(value) }
+        node("expires") { |value| parse_time(value) }
       end
 
 

--- a/lib/whois/parsers/whois.dns.pl.rb
+++ b/lib/whois/parsers/whois.dns.pl.rb
@@ -48,19 +48,19 @@ module Whois
 
       property_supported :created_on do
         if content_for_scanner =~ /created:\s+(.+?)\n/
-          Time.parse($1)
+          parse_time($1)
         end
       end
 
       property_supported :updated_on do
         if content_for_scanner =~ /last modified:\s+(.+?)\n/
-          Time.parse($1)
+          parse_time($1)
         end
       end
 
       property_supported :expires_on do
         if content_for_scanner =~ /renewal date:\s+(.+?)\n/ && $1 != "not defined"
-          Time.parse($1)
+          parse_time($1)
         end
       end
 

--- a/lib/whois/parsers/whois.domain-registry.nl.rb
+++ b/lib/whois/parsers/whois.domain-registry.nl.rb
@@ -65,13 +65,13 @@ module Whois
 
       property_supported :created_on do
         if content_for_scanner =~ /Date registered:\s+(.+)\n/
-          Time.parse($1)
+          parse_time($1)
         end
       end
 
       property_supported :updated_on do
         if content_for_scanner =~ /Record last updated:\s+(.+)\n/
-          Time.parse($1)
+          parse_time($1)
         end
       end
 

--- a/lib/whois/parsers/whois.domain.kg.rb
+++ b/lib/whois/parsers/whois.domain.kg.rb
@@ -45,19 +45,19 @@ module Whois
 
       property_supported :created_on do
         if content_for_scanner =~ /Record created: (.+?)\n/
-          Time.parse($1)
+          parse_time($1)
         end
       end
 
       property_supported :updated_on do
         if content_for_scanner =~ /Record last updated on (.+?)\n/
-          Time.parse($1)
+          parse_time($1)
         end
       end
 
       property_supported :expires_on do
         if content_for_scanner =~ /Record expires on (.+?)\n/
-          Time.parse($1)
+          parse_time($1)
         end
       end
 

--- a/lib/whois/parsers/whois.domainregistry.ie.rb
+++ b/lib/whois/parsers/whois.domainregistry.ie.rb
@@ -62,13 +62,13 @@ module Whois
 
 
       property_supported :created_on do
-        node("registration") { |value| Time.parse(value) }
+        node("registration") { |value| parse_time(value) }
       end
 
       property_not_supported :updated_on
 
       property_supported :expires_on do
-        node("renewal") { |value| Time.parse(value) }
+        node("renewal") { |value| parse_time(value) }
       end
 
 

--- a/lib/whois/parsers/whois.domreg.lt.rb
+++ b/lib/whois/parsers/whois.domreg.lt.rb
@@ -43,7 +43,7 @@ module Whois
 
       property_supported :created_on do
         if content_for_scanner =~ /Registered:\s+(.*)\n/
-          Time.parse($1)
+          parse_time($1)
         end
       end
 

--- a/lib/whois/parsers/whois.donuts.co.rb
+++ b/lib/whois/parsers/whois.donuts.co.rb
@@ -31,7 +31,7 @@ module Whois
 
       property_supported :expires_on do
         node('Registry Expiry Date') do |value|
-          Time.parse(value)
+          parse_time(value)
         end
       end
 

--- a/lib/whois/parsers/whois.educause.edu.rb
+++ b/lib/whois/parsers/whois.educause.edu.rb
@@ -60,19 +60,19 @@ module Whois
 
       property_supported :created_on do
         if content_for_scanner =~ /Domain record activated:\s+(.+?)\n/
-          Time.parse($1)
+          parse_time($1)
         end
       end
 
       property_supported :updated_on do
         if content_for_scanner =~ /Domain record last updated:\s+(.+?)\n/
-          Time.parse($1) unless $1 == 'unknown'
+          parse_time($1) unless $1 == 'unknown'
         end
       end
 
       property_supported :expires_on do
         if content_for_scanner =~ /Domain expires:\s+(.+?)\n/
-          Time.parse($1)
+          parse_time($1)
         end
       end
 

--- a/lib/whois/parsers/whois.educause.edu.rb
+++ b/lib/whois/parsers/whois.educause.edu.rb
@@ -66,7 +66,7 @@ module Whois
 
       property_supported :updated_on do
         if content_for_scanner =~ /Domain record last updated:\s+(.+?)\n/
-          parse_time($1) unless $1 == 'unknown'
+          parse_time($1)
         end
       end
 

--- a/lib/whois/parsers/whois.eenet.ee.rb
+++ b/lib/whois/parsers/whois.eenet.ee.rb
@@ -45,13 +45,13 @@ module Whois
 
       property_supported :created_on do
         if content_for_scanner =~ /Record created on (.*)\n/
-          Time.parse($1)
+          parse_time($1)
         end
       end
 
       property_supported :updated_on do
         if content_for_scanner =~ /Record changed on (.*)\n/
-          Time.parse($1)
+          parse_time($1)
         end
       end
 

--- a/lib/whois/parsers/whois.enom.com.rb
+++ b/lib/whois/parsers/whois.enom.com.rb
@@ -25,7 +25,7 @@ module Whois
 
       property_supported :updated_on do
         node('Updated Date') do |value|
-          parse_time(value) unless value.empty?
+          parse_time(value)
         end
       end
     end

--- a/lib/whois/parsers/whois.fi.rb
+++ b/lib/whois/parsers/whois.fi.rb
@@ -64,15 +64,15 @@ module Whois
 
 
       property_supported :created_on do
-        node("created") { |value| Time.parse(value) }
+        node("created") { |value| parse_time(value) }
       end
 
       property_supported :updated_on do
-        node("modified") { |value| Time.parse(value) }
+        node("modified") { |value| parse_time(value) }
       end
 
       property_supported :expires_on do
-        node("expires") { |value| Time.parse(value) }
+        node("expires") { |value| parse_time(value) }
       end
 
 

--- a/lib/whois/parsers/whois.godaddy.com.rb
+++ b/lib/whois/parsers/whois.godaddy.com.rb
@@ -34,19 +34,19 @@ module Whois
 
       property_supported :created_on do
         if content_for_scanner =~ /Creation Date: (.+)\n/
-          Time.parse($1)
+          parse_time($1)
         end
       end
 
       property_supported :updated_on do
         if content_for_scanner =~ /Updated* Date: (.+)\n/
-          Time.parse($1)
+          parse_time($1)
         end
       end
 
       property_supported :expires_on do
         if content_for_scanner =~ /Expiration Date: (.+)\n/
-          Time.parse($1)
+          parse_time($1)
         end
       end
 

--- a/lib/whois/parsers/whois.gov.za.rb
+++ b/lib/whois/parsers/whois.gov.za.rb
@@ -43,7 +43,7 @@ module Whois
 
       property_supported :created_on do
         if content_for_scanner =~ /Date : (.+)\n/
-          Time.parse($1)
+          parse_time($1)
         end
       end
 

--- a/lib/whois/parsers/whois.hkirc.hk.rb
+++ b/lib/whois/parsers/whois.hkirc.hk.rb
@@ -51,8 +51,7 @@ module Whois
 
       property_supported :expires_on do
         if content_for_scanner =~ /Expiry Date:\s(.+?)\n/
-          time = $1.strip
-          parse_time(time) unless time == 'null'
+          parse_time($1.strip)
         end
       end
 

--- a/lib/whois/parsers/whois.hkirc.hk.rb
+++ b/lib/whois/parsers/whois.hkirc.hk.rb
@@ -43,7 +43,7 @@ module Whois
 
       property_supported :created_on do
         if content_for_scanner =~ /Domain Name Commencement Date:\s(.+?)\n/
-          Time.parse($1)
+          parse_time($1)
         end
       end
 
@@ -52,7 +52,7 @@ module Whois
       property_supported :expires_on do
         if content_for_scanner =~ /Expiry Date:\s(.+?)\n/
           time = $1.strip
-          Time.parse(time) unless time == 'null'
+          parse_time(time) unless time == 'null'
         end
       end
 

--- a/lib/whois/parsers/whois.iana.org.rb
+++ b/lib/whois/parsers/whois.iana.org.rb
@@ -54,11 +54,11 @@ module Whois
 
 
       property_supported :created_on do
-        node("dates") { |raw| parse_time(raw["created"]) if raw.has_key? "created" }
+        node("dates") { |raw| parse_time(raw["created"]) }
       end
 
       property_supported :updated_on do
-        node("dates") { |raw| parse_time(raw["changed"]) if raw.has_key? "changed" }
+        node("dates") { |raw| parse_time(raw["changed"]) }
       end
 
       property_not_supported :expires_on

--- a/lib/whois/parsers/whois.iana.org.rb
+++ b/lib/whois/parsers/whois.iana.org.rb
@@ -54,11 +54,11 @@ module Whois
 
 
       property_supported :created_on do
-        node("dates") { |raw| Time.parse(raw["created"]) if raw.has_key? "created" }
+        node("dates") { |raw| parse_time(raw["created"]) if raw.has_key? "created" }
       end
 
       property_supported :updated_on do
-        node("dates") { |raw| Time.parse(raw["changed"]) if raw.has_key? "changed" }
+        node("dates") { |raw| parse_time(raw["changed"]) if raw.has_key? "changed" }
       end
 
       property_not_supported :expires_on

--- a/lib/whois/parsers/whois.isnic.is.rb
+++ b/lib/whois/parsers/whois.isnic.is.rb
@@ -45,7 +45,7 @@ module Whois
 
       property_supported :created_on do
         if content_for_scanner =~ /created:\s+(.*)\n/
-          Time.parse($1)
+          parse_time($1)
         end
       end
 
@@ -53,7 +53,7 @@ module Whois
 
       property_supported :expires_on do
         if content_for_scanner =~ /expires:\s+(.*)\n/
-          Time.parse($1)
+          parse_time($1)
         end
       end
 

--- a/lib/whois/parsers/whois.isoc.org.il.rb
+++ b/lib/whois/parsers/whois.isoc.org.il.rb
@@ -56,7 +56,7 @@ module Whois
       property_supported :updated_on do
         if content_for_scanner =~ /changed:\s+(.+)\n/
           t = content_for_scanner.scan(/changed:\s+(?:.+?) (\d+) \(.+\)\n/).flatten.last
-          Time.parse(t)
+          parse_time(t)
         end
       end
 

--- a/lib/whois/parsers/whois.ja.net.rb
+++ b/lib/whois/parsers/whois.ja.net.rb
@@ -43,19 +43,19 @@ module Whois
 
       property_supported :created_on do
         if content_for_scanner =~ /^Entry created:\n\s+(.+?)\n/
-          Time.parse($1)
+          parse_time($1)
         end
       end
 
       property_supported :updated_on do
         if content_for_scanner =~ /^Entry updated:\n\s+(.+?)\n/
-          Time.parse($1)
+          parse_time($1)
         end
       end
 
       property_supported :expires_on do
         if content_for_scanner =~ /^Renewal date:\n\s+(.+?)\n/
-          Time.parse($1)
+          parse_time($1)
         end
       end
 

--- a/lib/whois/parsers/whois.jprs.jp.rb
+++ b/lib/whois/parsers/whois.jprs.jp.rb
@@ -66,21 +66,21 @@ module Whois
       # TODO: timezone ('Asia/Tokyo')
       property_supported :created_on do
         if content_for_scanner =~ /\[(?:Created on|Registered Date)\][ \t]+(.*)\n/
-          ($1.empty?) ? nil : Time.parse($1)
+          ($1.empty?) ? nil : parse_time($1)
         end
       end
 
       # TODO: timezone ('Asia/Tokyo')
       property_supported :updated_on do
         if content_for_scanner =~ /\[Last Updated?\][ \t]+(.*)\n/
-          ($1.empty?) ? nil : Time.parse($1)
+          ($1.empty?) ? nil : parse_time($1)
         end
       end
 
       # TODO: timezone ('Asia/Tokyo')
       property_supported :expires_on do
         if content_for_scanner =~ /\[(?:Expires on|State)\][ \t]+(.*)\n/
-          ($1.empty?) ? nil : Time.parse($1)
+          ($1.empty?) ? nil : parse_time($1)
         end
       end
 

--- a/lib/whois/parsers/whois.kenic.or.ke.rb
+++ b/lib/whois/parsers/whois.kenic.or.ke.rb
@@ -52,19 +52,19 @@ module Whois
 
       property_supported :created_on do
         if content_for_scanner =~ /Created:\s+(.+?)\n/
-          Time.parse($1)
+          parse_time($1)
         end
       end
 
       property_supported :updated_on do
         if content_for_scanner =~ /Modified:\s+(.+?)\n/
-          Time.parse($1)
+          parse_time($1)
         end
       end
 
       property_supported :expires_on do
         if content_for_scanner =~ /Expires:\s+(.+?)\n/
-          Time.parse($1)
+          parse_time($1)
         end
       end
 

--- a/lib/whois/parsers/whois.kr.rb
+++ b/lib/whois/parsers/whois.kr.rb
@@ -43,19 +43,19 @@ module Whois
 
       property_supported :created_on do
         if content_for_scanner =~ /Registered Date\s+:\s+(.+)\n/
-          Time.parse($1)
+          parse_time($1)
         end
       end
 
       property_supported :updated_on do
         if content_for_scanner =~ /Last Updated Date\s+:\s+(.+)\n/
-          Time.parse($1)
+          parse_time($1)
         end
       end
 
       property_supported :expires_on do
         if content_for_scanner =~ /Expiration Date\s+:\s+(.+)\n/
-          Time.parse($1)
+          parse_time($1)
         end
       end
 

--- a/lib/whois/parsers/whois.museum.rb
+++ b/lib/whois/parsers/whois.museum.rb
@@ -45,19 +45,19 @@ module Whois
 
       property_supported :created_on do
         if content_for_scanner =~ /Created On:(.*?)\n/
-          Time.parse($1)
+          parse_time($1)
         end
       end
 
       property_supported :updated_on do
         if content_for_scanner =~ /Last Updated On:(.*?)\n/
-          Time.parse($1)
+          parse_time($1)
         end
       end
 
       property_supported :expires_on do
         if content_for_scanner =~ /Expiration Date:(.*?)\n/
-          Time.parse($1)
+          parse_time($1)
         end
       end
 

--- a/lib/whois/parsers/whois.mynic.my.rb
+++ b/lib/whois/parsers/whois.mynic.my.rb
@@ -42,19 +42,19 @@ module Whois
 
       property_supported :created_on do
         if content_for_scanner =~ /\[Record Created\]\s+(.+?)\n/
-          Time.parse($1)
+          parse_time($1)
         end
       end
 
       property_supported :updated_on do
         if content_for_scanner =~ /\[Record Last Modified\]\s+(.+?)\n/
-          Time.parse($1)
+          parse_time($1)
         end
       end
 
       property_supported :expires_on do
         if content_for_scanner =~ /\[Record Expired\]\s+(.+?)\n/
-          Time.parse($1)
+          parse_time($1)
         end
       end
 

--- a/lib/whois/parsers/whois.nc.rb
+++ b/lib/whois/parsers/whois.nc.rb
@@ -53,15 +53,15 @@ module Whois
 
 
       property_supported :created_on do
-        node("Created on") { |value| Time.parse(value) }
+        node("Created on") { |value| parse_time(value) }
       end
 
       property_supported :updated_on do
-        node("Last updated on") { |value| Time.parse(value) }
+        node("Last updated on") { |value| parse_time(value) }
       end
 
       property_supported :expires_on do
-        node("Expires on") { |value| Time.parse(value) }
+        node("Expires on") { |value| parse_time(value) }
       end
 
 

--- a/lib/whois/parsers/whois.nic.asia.rb
+++ b/lib/whois/parsers/whois.nic.asia.rb
@@ -36,19 +36,19 @@ module Whois
 
       property_supported :created_on do
         node("Domain Create Date") do |value|
-          Time.parse(value)
+          parse_time(value)
         end
       end
 
       property_supported :updated_on do
         node("Domain Last Updated Date") do |value|
-          Time.parse(value)
+          parse_time(value)
         end
       end
 
       property_supported :expires_on do
         node("Domain Expiration Date") do |value|
-          Time.parse(value)
+          parse_time(value)
         end
       end
 

--- a/lib/whois/parsers/whois.nic.at.rb
+++ b/lib/whois/parsers/whois.nic.at.rb
@@ -45,7 +45,7 @@ module Whois
 
       property_supported :updated_on do
         if content_for_scanner =~ /changed:\s+(.*)\n/
-          Time.parse($1)
+          parse_time($1)
         end
       end
 

--- a/lib/whois/parsers/whois.nic.bj.rb
+++ b/lib/whois/parsers/whois.nic.bj.rb
@@ -52,13 +52,13 @@ module Whois
 
       property_supported :created_on do
         if section =~ /Created:\s+(.+)\n/
-          Time.parse($1)
+          parse_time($1)
         end
       end
 
       property_supported :updated_on do
         if section =~ /Updated:\s+(.+)\n/
-          Time.parse($1)
+          parse_time($1)
         end
       end
 

--- a/lib/whois/parsers/whois.nic.bo.rb
+++ b/lib/whois/parsers/whois.nic.bo.rb
@@ -52,7 +52,7 @@ module Whois
 
       property_supported :created_on do
         if content_for_scanner =~ /Fecha de registro:(.*)\n/
-          Time.parse($1)
+          parse_time($1)
         end
       end
 
@@ -60,7 +60,7 @@ module Whois
 
       property_supported :expires_on do
         if content_for_scanner =~ /Fecha de vencimiento:(.*)\n/
-          Time.parse($1)
+          parse_time($1)
         end
       end
 

--- a/lib/whois/parsers/whois.nic.ci.rb
+++ b/lib/whois/parsers/whois.nic.ci.rb
@@ -45,7 +45,7 @@ module Whois
 
       property_supported :created_on do
         if content_for_scanner =~ /Created: (.+?)\n/
-          Time.parse($1)
+          parse_time($1)
         end
       end
 
@@ -53,7 +53,7 @@ module Whois
 
       property_supported :expires_on do
         if content_for_scanner =~ /Expiration date: (.+?)\n/
-          Time.parse($1)
+          parse_time($1)
         end
       end
 

--- a/lib/whois/parsers/whois.nic.cl.rb
+++ b/lib/whois/parsers/whois.nic.cl.rb
@@ -48,7 +48,7 @@ module Whois
       # TODO: custom date format with foreign month names
       # property_supported :updated_on do
       #   if content_for_scanner =~ /changed:\s+(.*)\n/
-      #     Time.parse($1.split(" ", 2).last)
+      #     parse_time($1.split(" ", 2).last)
       #   end
       # end
 

--- a/lib/whois/parsers/whois.nic.coop.rb
+++ b/lib/whois/parsers/whois.nic.coop.rb
@@ -41,19 +41,19 @@ module Whois
 
       property_supported :created_on do
         if content_for_scanner =~ /Created:\s+(.*)\n/
-          Time.parse($1)
+          parse_time($1)
         end
       end
 
       property_supported :updated_on do
         if content_for_scanner =~ /Last updated:\s+(.*)\n/
-          Time.parse($1)
+          parse_time($1)
         end
       end
 
       property_supported :expires_on do
         if content_for_scanner =~ /Expiry Date:\s+(.*)\n/
-          Time.parse($1)
+          parse_time($1)
         end
       end
 

--- a/lib/whois/parsers/whois.nic.es.rb
+++ b/lib/whois/parsers/whois.nic.es.rb
@@ -48,7 +48,7 @@ module Whois
 
       property_supported :created_on do
         if content_for_scanner =~ /Creation Date:\s+(.+)\n/
-          Time.parse($1)
+          parse_time($1)
         end
       end
 
@@ -56,7 +56,7 @@ module Whois
 
       property_supported :expires_on do
         if content_for_scanner =~ /Expiration Date:\s+(.+)\n/
-          Time.parse($1)
+          parse_time($1)
         end
       end
 

--- a/lib/whois/parsers/whois.nic.hu.rb
+++ b/lib/whois/parsers/whois.nic.hu.rb
@@ -51,7 +51,7 @@ module Whois
 
       property_supported :created_on do
         if content_for_scanner =~ /record created:\s+(.+)\n/
-          Time.parse($1)
+          parse_time($1)
         end
       end
 

--- a/lib/whois/parsers/whois.nic.im.rb
+++ b/lib/whois/parsers/whois.nic.im.rb
@@ -49,7 +49,7 @@ module Whois
 
       property_supported :expires_on do
         if content_for_scanner =~ /Expiry Date:\s+(.*?)\n/
-          Time.parse($1.gsub("/", "-"))
+          parse_time($1.gsub("/", "-"))
         end
       end
 

--- a/lib/whois/parsers/whois.nic.ir.rb
+++ b/lib/whois/parsers/whois.nic.ir.rb
@@ -47,7 +47,7 @@ module Whois
 
       property_supported :updated_on do
         if content_for_scanner =~ /last-updated:\s+(.*)\n/
-          Time.parse($1)
+          parse_time($1)
         end
       end
 

--- a/lib/whois/parsers/whois.nic.it.rb
+++ b/lib/whois/parsers/whois.nic.it.rb
@@ -79,15 +79,15 @@ module Whois
 
 
       property_supported :created_on do
-        node("Created") { |str| Time.parse(str) }
+        node("Created") { |str| parse_time(str) }
       end
 
       property_supported :updated_on do
-        node("Last Update") { |str| Time.parse(str) }
+        node("Last Update") { |str| parse_time(str) }
       end
 
       property_supported :expires_on do
-        node("Expire Date") { |str| Time.parse(str) }
+        node("Expire Date") { |str| parse_time(str) }
       end
 
 
@@ -147,8 +147,8 @@ module Whois
             :zip          => address[2],
             :state        => address[3],
             :country_code => address[4],
-            :created_on   => str["Created"] ? Time.parse(str["Created"]) : nil,
-            :updated_on   => str["Last Update"] ? Time.parse(str["Last Update"]) : nil
+            :created_on   => str["Created"] ? parse_time(str["Created"]) : nil,
+            :updated_on   => str["Last Update"] ? parse_time(str["Last Update"]) : nil
           )
         end
       end

--- a/lib/whois/parsers/whois.nic.kz.rb
+++ b/lib/whois/parsers/whois.nic.kz.rb
@@ -42,13 +42,13 @@ module Whois
 
       property_supported :created_on do
         if content_for_scanner =~ /Domain created: (.+)\n/
-          Time.parse($1)
+          parse_time($1)
         end
       end
 
       property_supported :updated_on do
         if content_for_scanner =~ /Last modified : (.+)\n/ && !(value = $1).empty?
-          Time.parse(value)
+          parse_time(value)
         end
       end
 

--- a/lib/whois/parsers/whois.nic.lk.rb
+++ b/lib/whois/parsers/whois.nic.lk.rb
@@ -51,13 +51,13 @@ module Whois
 
       property_supported :created_on do
         if content_for_scanner =~ /Created on\.+:(.+)\n/
-          parse_time($1) unless $1 == "null"
+          parse_time($1)
         end
       end
 
       property_supported :updated_on do
         if content_for_scanner =~ /Record last updated on\.+:(.+)\n/
-          parse_time($1) unless $1 == "null"
+          parse_time($1)
         end
       end
 

--- a/lib/whois/parsers/whois.nic.lk.rb
+++ b/lib/whois/parsers/whois.nic.lk.rb
@@ -51,19 +51,19 @@ module Whois
 
       property_supported :created_on do
         if content_for_scanner =~ /Created on\.+:(.+)\n/
-          Time.parse($1) unless $1 == "null"
+          parse_time($1) unless $1 == "null"
         end
       end
 
       property_supported :updated_on do
         if content_for_scanner =~ /Record last updated on\.+:(.+)\n/
-          Time.parse($1) unless $1 == "null"
+          parse_time($1) unless $1 == "null"
         end
       end
 
       property_supported :expires_on do
         if content_for_scanner =~ /Expires on\.+:(.+)\n/
-          Time.parse($1)
+          parse_time($1)
         end
       end
 

--- a/lib/whois/parsers/whois.nic.lv.rb
+++ b/lib/whois/parsers/whois.nic.lv.rb
@@ -46,9 +46,7 @@ module Whois
 
       property_supported :updated_on do
         if content_for_scanner =~ /Changed:\s+(.+)\n/
-          # Hack to remove usec. Do you know a better way?
-          # Time.utc(*Time.parse($1).to_a)
-          Time.parse($1)
+          parse_time($1)
         end
       end
 

--- a/lib/whois/parsers/whois.nic.ly.rb
+++ b/lib/whois/parsers/whois.nic.ly.rb
@@ -45,19 +45,19 @@ module Whois
 
       property_supported :created_on do
         if content_for_scanner =~ /Created:\s+(.*)\n/
-          Time.parse($1)
+          parse_time($1)
         end
       end
 
       property_supported :updated_on do
         if content_for_scanner =~ /Updated:\s+(.*)\n/
-          Time.parse($1)
+          parse_time($1)
         end
       end
 
       property_supported :expires_on do
         if content_for_scanner =~ /Expired:\s+(.*)\n/
-          Time.parse($1)
+          parse_time($1)
         end
       end
 

--- a/lib/whois/parsers/whois.nic.md.rb
+++ b/lib/whois/parsers/whois.nic.md.rb
@@ -51,7 +51,7 @@ module Whois
 
       property_supported :created_on do
         if content_for_scanner =~ /Created:\s(.+?)\n/
-          Time.parse($1)
+          parse_time($1)
         end
       end
 
@@ -59,7 +59,7 @@ module Whois
 
       property_supported :expires_on do
         if content_for_scanner =~ /Expiration date:\s+(.+?)\n/
-          Time.parse($1)
+          parse_time($1)
         end
       end
 

--- a/lib/whois/parsers/whois.nic.me.rb
+++ b/lib/whois/parsers/whois.nic.me.rb
@@ -29,7 +29,7 @@ module Whois
 
       property_supported :updated_on do
         node("Domain Last Updated Date") do |value|
-          parse_time(value) unless value.empty?
+          parse_time(value)
         end
       end
 

--- a/lib/whois/parsers/whois.nic.me.rb
+++ b/lib/whois/parsers/whois.nic.me.rb
@@ -23,19 +23,19 @@ module Whois
 
       property_supported :created_on do
         node("Domain Create Date") do |value|
-          Time.parse(value)
+          parse_time(value)
         end
       end
 
       property_supported :updated_on do
         node("Domain Last Updated Date") do |value|
-          Time.parse(value) unless value.empty?
+          parse_time(value) unless value.empty?
         end
       end
 
       property_supported :expires_on do
         node("Domain Expiration Date") do |value|
-          Time.parse(value)
+          parse_time(value)
         end
       end
 

--- a/lib/whois/parsers/whois.nic.mx.rb
+++ b/lib/whois/parsers/whois.nic.mx.rb
@@ -45,7 +45,7 @@ module Whois
 
       property_supported :created_on do
         if content_for_scanner =~ /Created On:\s+(.*)\n/
-          Time.parse($1)
+          parse_time($1)
         end
       end
 
@@ -54,13 +54,13 @@ module Whois
       # Last Updated On: 15-abr-2010 <--
       # property_supported :updated_on do
       #   if content_for_scanner =~ /Last Updated On:\s+(.*)\n/
-      #     Time.parse($1)
+      #     parse_time($1)
       #   end
       # end
 
       property_supported :expires_on do
         if content_for_scanner =~ /Expiration Date:\s+(.*)\n/
-          Time.parse($1)
+          parse_time($1)
         end
       end
 

--- a/lib/whois/parsers/whois.nic.name.rb
+++ b/lib/whois/parsers/whois.nic.name.rb
@@ -39,19 +39,19 @@ module Whois
 
       property_supported :created_on do
         if content_for_scanner =~ /Created On: (.+)\n/
-          Time.parse($1)
+          parse_time($1)
         end
       end
 
       property_supported :updated_on do
         if content_for_scanner =~ /Updated On: (.+)\n/
-          Time.parse($1)
+          parse_time($1)
         end
       end
 
       property_supported :expires_on do
         if content_for_scanner =~ /Expires On: (.+)\n/
-          Time.parse($1)
+          parse_time($1)
         end
       end
 

--- a/lib/whois/parsers/whois.nic.net.sa.rb
+++ b/lib/whois/parsers/whois.nic.net.sa.rb
@@ -43,13 +43,13 @@ module Whois
 
       property_supported :created_on do
         if content_for_scanner =~ /Created on: (.+)\n/
-          Time.parse($1)
+          parse_time($1)
         end
       end
 
       property_supported :updated_on do
         if content_for_scanner =~ /Last Updated on: (.+)\n/
-          Time.parse($1)
+          parse_time($1)
         end
       end
 

--- a/lib/whois/parsers/whois.nic.org.uy.rb
+++ b/lib/whois/parsers/whois.nic.org.uy.rb
@@ -48,13 +48,13 @@ module Whois
 
       property_supported :created_on do
         if content_for_scanner =~ /Fecha de Creacion: (.+)\n/
-          Time.parse($1)
+          parse_time($1)
         end
       end
 
       property_supported :updated_on do
         if content_for_scanner =~ /Ultima Actualizacion: (.+)\n/
-          Time.parse($1)
+          parse_time($1)
         end
       end
 

--- a/lib/whois/parsers/whois.nic.pr.rb
+++ b/lib/whois/parsers/whois.nic.pr.rb
@@ -50,7 +50,7 @@ module Whois
 
       property_supported :created_on do
         if content_for_scanner =~ /Created On:\s+(.+)\n/
-          Time.parse($1)
+          parse_time($1)
         end
       end
 
@@ -58,7 +58,7 @@ module Whois
 
       property_supported :expires_on do
         if content_for_scanner =~ /Expires On:\s+(.+)\n/
-          Time.parse($1)
+          parse_time($1)
         end
       end
 

--- a/lib/whois/parsers/whois.nic.priv.at.rb
+++ b/lib/whois/parsers/whois.nic.priv.at.rb
@@ -47,7 +47,7 @@ module Whois
 
       property_supported :updated_on do
         if content_for_scanner =~ /changed:\s+(.+)\n/
-          Time.parse($1.strip.split(" ").last)
+          parse_time($1.strip.split(" ").last)
         end
       end
 

--- a/lib/whois/parsers/whois.nic.sl.rb
+++ b/lib/whois/parsers/whois.nic.sl.rb
@@ -45,21 +45,21 @@ module Whois
 
       property_supported :created_on do
         if content_for_scanner =~ /^Registration Date:\s+(.+)\n/
-          Time.parse($1)
+          parse_time($1)
         end
       end
 
       property_supported :updated_on do
         if content_for_scanner =~ /^Last Updated:\s+(.+)\n/
           if $1 != "0000-00-00"
-            Time.parse($1)
+            parse_time($1)
           end
         end
       end
 
       property_supported :expires_on do
         if content_for_scanner =~ /^Expiration Date:\s+(.+)\n/
-          Time.parse($1)
+          parse_time($1)
         end
       end
 

--- a/lib/whois/parsers/whois.nic.sn.rb
+++ b/lib/whois/parsers/whois.nic.sn.rb
@@ -52,7 +52,7 @@ module Whois
 
       property_supported :created_on do
         if content_for_scanner =~ /Created:\s+(.+)\n/
-          Time.parse($1)
+          parse_time($1)
         end
       end
 

--- a/lib/whois/parsers/whois.nic.so.rb
+++ b/lib/whois/parsers/whois.nic.so.rb
@@ -41,19 +41,19 @@ module Whois
 
       property_supported :created_on do
         if content_for_scanner =~ /Creation Date:\s+(.+)\n/
-          Time.parse($1)
+          parse_time($1)
         end
       end
 
       property_supported :updated_on do
         if content_for_scanner =~ /Last Updated On:\s+(.+)\n/
-          Time.parse($1)
+          parse_time($1)
         end
       end
 
       property_supported :expires_on do
         if content_for_scanner =~ /Expiration Date:\s+(.+)\n/
-          Time.parse($1)
+          parse_time($1)
         end
       end
 

--- a/lib/whois/parsers/whois.nic.st.rb
+++ b/lib/whois/parsers/whois.nic.st.rb
@@ -45,13 +45,13 @@ module Whois
 
       property_supported :created_on do
         if content_for_scanner =~ /\s+Creation Date:\s+(.*)\n/
-          Time.parse($1)
+          parse_time($1)
         end
       end
 
       property_supported :updated_on do
         if content_for_scanner =~ /\s+Updated Date:\s+(.*)\n/
-          Time.parse($1)
+          parse_time($1)
         end
       end
 

--- a/lib/whois/parsers/whois.nic.tr.rb
+++ b/lib/whois/parsers/whois.nic.tr.rb
@@ -50,7 +50,7 @@ module Whois
 
       property_supported :created_on do
         if content_for_scanner =~ /Created on\.+:\s+(.+)\n/
-          time = Time.parse($1)
+          time = parse_time($1)
           Time.utc(time.year, time.month, time.day)
         end
       end
@@ -59,7 +59,7 @@ module Whois
 
       property_supported :expires_on do
         if content_for_scanner =~ /Expires on\.+:\s+(.+)\n/
-          time = Time.parse($1)
+          time = parse_time($1)
           Time.utc(time.year, time.month, time.day)
         end
       end

--- a/lib/whois/parsers/whois.nic.uk.rb
+++ b/lib/whois/parsers/whois.nic.uk.rb
@@ -65,19 +65,19 @@ module Whois
 
       property_supported :created_on do
         if content_for_scanner =~ /\s+Registered on:\s+(.+)\n/
-          Time.parse($1)
+          parse_time($1)
         end
       end
 
       property_supported :updated_on do
         if content_for_scanner =~ /\s+Last updated:\s+(.+)\n/
-          Time.parse($1)
+          parse_time($1)
         end
       end
 
       property_supported :expires_on do
         if content_for_scanner =~ /\s+Expiry date:\s+(.+)\n/
-          Time.parse($1)
+          parse_time($1)
         end
       end
 

--- a/lib/whois/parsers/whois.nic.ve.rb
+++ b/lib/whois/parsers/whois.nic.ve.rb
@@ -52,19 +52,19 @@ module Whois
 
       property_supported :created_on do
         if content_for_scanner =~ /Fecha de Creacion: (.+?)\n/
-          Time.parse($1)
+          parse_time($1)
         end
       end
 
       property_supported :updated_on do
         if content_for_scanner =~ /Ultima Actualizacion: (.+?)\n/
-          Time.parse($1)
+          parse_time($1)
         end
       end
 
       property_supported :expires_on do
         if content_for_scanner =~ /Fecha de Vencimiento: (.+?)\n/
-          Time.parse($1)
+          parse_time($1)
         end
       end
 

--- a/lib/whois/parsers/whois.norid.no.rb
+++ b/lib/whois/parsers/whois.norid.no.rb
@@ -43,13 +43,13 @@ module Whois
 
       property_supported :created_on do
         if content_for_scanner =~ /Created:\s+(.*)\n/
-          Time.parse($1)
+          parse_time($1)
         end
       end
 
       property_supported :updated_on do
         if content_for_scanner =~ /Last updated:\s+(.*)\n/
-          Time.parse($1)
+          parse_time($1)
         end
       end
 

--- a/lib/whois/parsers/whois.pir.org.rb
+++ b/lib/whois/parsers/whois.pir.org.rb
@@ -44,19 +44,19 @@ module Whois
 
       property_supported :created_on do
         node("Creation Date") do |value|
-          Time.parse(value)
+          parse_time(value)
         end
       end
 
       property_supported :updated_on do
         node("Updated Date") do |value|
-          Time.parse(value)
+          parse_time(value)
         end
       end
 
       property_supported :expires_on do
         node("Registry Expiry Date") do |value|
-          Time.parse(value)
+          parse_time(value)
         end
       end
 

--- a/lib/whois/parsers/whois.register.bg.rb
+++ b/lib/whois/parsers/whois.register.bg.rb
@@ -50,7 +50,7 @@ module Whois
         if content_for_scanner =~ /activated on:\s+(.*?)\n/
           # Time.parse("30/06/2003 00:00:00")
           # => ArgumentError: argument out of range
-          Time.parse($1.gsub("/", "-"))
+          parse_time($1.gsub("/", "-"))
         end
       end
 
@@ -60,7 +60,7 @@ module Whois
         if content_for_scanner =~ /expires at:\s+(.*?)\n/
           # Time.parse("30/06/2003 00:00:00")
           # => ArgumentError: argument out of range
-          Time.parse($1.gsub("/", "-"))
+          parse_time($1.gsub("/", "-"))
         end
       end
 

--- a/lib/whois/parsers/whois.register.com.rb
+++ b/lib/whois/parsers/whois.register.com.rb
@@ -21,7 +21,7 @@ module Whois
     class WhoisRegisterCom < BaseIcannCompliant
       property_supported :updated_on do
         node('Updated Date') do |value|
-          parse_time(value) unless value.empty?
+          parse_time(value)
         end
       end
     end

--- a/lib/whois/parsers/whois.register.si.rb
+++ b/lib/whois/parsers/whois.register.si.rb
@@ -48,7 +48,7 @@ module Whois
 
       property_supported :created_on do
         if content_for_scanner =~ /created:\s+(.*)\n/
-          Time.parse($1)
+          parse_time($1)
         end
       end
 
@@ -56,7 +56,7 @@ module Whois
 
       property_supported :expires_on do
         if content_for_scanner =~ /expire:\s+(.*)\n/
-          Time.parse($1)
+          parse_time($1)
         end
       end
 

--- a/lib/whois/parsers/whois.registre.ma.rb
+++ b/lib/whois/parsers/whois.registre.ma.rb
@@ -45,13 +45,13 @@ module Whois
 
       property_supported :created_on do
         if content_for_scanner =~ /domain:Created:(.+?)\n/
-          Time.parse($1)
+          parse_time($1)
         end
       end
 
       property_supported :updated_on do
         if content_for_scanner =~ /domain:Updated:(.+?)\n/
-          Time.parse($1)
+          parse_time($1)
         end
       end
 

--- a/lib/whois/parsers/whois.registro.br.rb
+++ b/lib/whois/parsers/whois.registro.br.rb
@@ -44,19 +44,19 @@ module Whois
 
       property_supported :created_on do
         if content_for_scanner =~ /created:\s+(.+?)(\s+#.+)?\n/
-          Time.parse($1)
+          parse_time($1)
         end
       end
 
       property_supported :updated_on do
         if content_for_scanner =~ /changed:\s+(.+?)\n/
-          Time.parse($1)
+          parse_time($1)
         end
       end
 
       property_supported :expires_on do
         if content_for_scanner =~ /expires:\s+(.+?)\n/
-          Time.parse($1)
+          parse_time($1)
         end
       end
 

--- a/lib/whois/parsers/whois.registry.hm.rb
+++ b/lib/whois/parsers/whois.registry.hm.rb
@@ -47,7 +47,7 @@ module Whois
         if content_for_scanner =~ /Domain creation date: (.+?)\n/
           # Change dd/mm/yy to yyyy-mm-dd to prevent
           # argument out of range
-          Time.parse($1.split("/").reverse.join("-"))
+          parse_time($1.split("/").reverse.join("-"))
         end
       end
 
@@ -55,7 +55,7 @@ module Whois
 
       property_supported :expires_on do
         if content_for_scanner =~ /Domain expiration date: (.+?)\n/
-          Time.parse($1.split("/").reverse.join("-"))
+          parse_time($1.split("/").reverse.join("-"))
         end
       end
 

--- a/lib/whois/parsers/whois.registry.net.za.rb
+++ b/lib/whois/parsers/whois.registry.net.za.rb
@@ -62,7 +62,7 @@ module Whois
       property_supported :created_on do
         node("node:dates") do |array|
           array[0] =~ /Registration Date:\s*(\d{4}-\d{2}-\d{2})/
-          parse_date($1)
+          parse_time($1)
         end
       end
 
@@ -71,7 +71,7 @@ module Whois
       property_supported :expires_on do
         node("node:dates") do |array|
           array[1] =~ /Renewal Date:\s*(\d{4}-\d{2}-\d{2})/
-          parse_date($1)
+          parse_time($1)
         end
       end
 
@@ -131,10 +131,6 @@ module Whois
             fax:          fax,
             email:        email
         )
-      end
-
-      def parse_date(date_string)
-        parse_time(date_string) if date_string
       end
 
     end

--- a/lib/whois/parsers/whois.registry.net.za.rb
+++ b/lib/whois/parsers/whois.registry.net.za.rb
@@ -134,7 +134,7 @@ module Whois
       end
 
       def parse_date(date_string)
-        Time.parse(date_string) if date_string
+        parse_time(date_string) if date_string
       end
 
     end

--- a/lib/whois/parsers/whois.registry.om.rb
+++ b/lib/whois/parsers/whois.registry.om.rb
@@ -26,7 +26,7 @@ module Whois
 
 
       property_supported :updated_on do
-        node("Last Modified") { |value| Time.parse(value) }
+        node("Last Modified") { |value| parse_time(value) }
       end
 
 

--- a/lib/whois/parsers/whois.rnids.rs.rb
+++ b/lib/whois/parsers/whois.rnids.rs.rb
@@ -62,15 +62,15 @@ module Whois
 
 
       property_supported :created_on do
-        node("Registration date") { |value| Time.parse(value) }
+        node("Registration date") { |value| parse_time(value) }
       end
 
       property_supported :updated_on do
-        node("Modification date") { |value| Time.parse(value) }
+        node("Modification date") { |value| parse_time(value) }
       end
 
       property_supported :expires_on do
-        node("Expiration date") { |value| Time.parse(value) }
+        node("Expiration date") { |value| parse_time(value) }
       end
 
 

--- a/lib/whois/parsers/whois.schlund.info.rb
+++ b/lib/whois/parsers/whois.schlund.info.rb
@@ -25,7 +25,7 @@ module Whois
 
       property_supported :updated_on do
         node('Updated Date') do |value|
-          parse_time(value) unless value.empty?
+          parse_time(value)
         end
       end
     end

--- a/lib/whois/parsers/whois.sgnic.sg.rb
+++ b/lib/whois/parsers/whois.sgnic.sg.rb
@@ -41,7 +41,7 @@ module Whois
 
       property_supported :created_on do
         if content_for_scanner =~ /^\s+Creation Date:\s+(.*)\n/
-          Time.parse($1)
+          parse_time($1)
         end
       end
 
@@ -49,7 +49,7 @@ module Whois
 
       property_supported :expires_on do
         if content_for_scanner =~ /^\s+Expiration Date:\s+(.*)\n/
-          Time.parse($1)
+          parse_time($1)
         end
       end
 

--- a/lib/whois/parsers/whois.sk-nic.sk.rb
+++ b/lib/whois/parsers/whois.sk-nic.sk.rb
@@ -78,13 +78,13 @@ module Whois
 
       property_supported :updated_on do
         if content_for_scanner =~ /^Last-update\s+(.+)\n/
-          Time.parse($1)
+          parse_time($1)
         end
       end
 
       property_supported :expires_on do
         if content_for_scanner =~ /^Valid-date\s+(.+)\n/
-          Time.parse($1)
+          parse_time($1)
         end
       end
 

--- a/lib/whois/parsers/whois.smallregistry.net.rb
+++ b/lib/whois/parsers/whois.smallregistry.net.rb
@@ -64,15 +64,15 @@ module Whois
 
 
       property_supported :created_on do
-        node("created") { |str| Time.parse(str) }
+        node("created") { |str| parse_time(str) }
       end
 
       property_supported :updated_on do
-        node("updated") { |str| Time.parse(str) }
+        node("updated") { |str| parse_time(str) }
       end
 
       property_supported :expires_on do
-        node("expired") { |str| Time.parse(str) }
+        node("expired") { |str| parse_time(str) }
       end
 
 
@@ -121,7 +121,7 @@ module Whois
             :phone        => hash['phone'],
             :fax          => hash['fax'],
             :email        => hash['mobile'],
-            :updated_on   => Time.parse(hash['updated'])
+            :updated_on   => parse_time(hash['updated'])
           )
         end
       end

--- a/lib/whois/parsers/whois.srs.net.nz.rb
+++ b/lib/whois/parsers/whois.srs.net.nz.rb
@@ -64,15 +64,15 @@ module Whois
 
 
       property_supported :created_on do
-        node("domain_dateregistered") { |value| Time.parse(value) }
+        node("domain_dateregistered") { |value| parse_time(value) }
       end
 
       property_supported :updated_on do
-        node("domain_datelastmodified") { |value| Time.parse(value) }
+        node("domain_datelastmodified") { |value| parse_time(value) }
       end
 
       property_supported :expires_on do
-        node("domain_datebilleduntil") { |value| Time.parse(value) }
+        node("domain_datebilleduntil") { |value| parse_time(value) }
       end
 
 

--- a/lib/whois/parsers/whois.sx.rb
+++ b/lib/whois/parsers/whois.sx.rb
@@ -105,11 +105,6 @@ module Whois
 
       private
 
-      def parse_time(value)
-        # Hack to remove usec. Do you know a better way?
-        Time.utc(*Time.parse(value).to_a)
-      end
-
       def build_contact(element, type)
         node("#{element} ID") do |id|
           Parser::Contact.new(

--- a/lib/whois/parsers/whois.tcinet.ru.rb
+++ b/lib/whois/parsers/whois.tcinet.ru.rb
@@ -52,7 +52,7 @@ module Whois
 
       property_supported :created_on do
         if content_for_scanner =~ /created:\s+(.*)\n/
-          Time.parse($1)
+          parse_time($1)
         end
       end
 
@@ -60,7 +60,7 @@ module Whois
 
       property_supported :expires_on do
         if content_for_scanner =~ /paid-till:\s+(.*)\n/
-          Time.parse($1)
+          parse_time($1)
         end
       end
 

--- a/lib/whois/parsers/whois.thnic.co.th.rb
+++ b/lib/whois/parsers/whois.thnic.co.th.rb
@@ -50,19 +50,19 @@ module Whois
 
       property_supported :created_on do
         if content_for_scanner =~ /^Created date: (.+?)\n/
-          Time.parse($1)
+          parse_time($1)
         end
       end
 
       property_supported :updated_on do
         if content_for_scanner =~ /^Updated date: (.+?)\n/
-          Time.parse($1)
+          parse_time($1)
         end
       end
 
       property_supported :expires_on do
         if content_for_scanner =~ /^Exp date: (.+?)\n/
-          Time.parse($1)
+          parse_time($1)
         end
       end
 

--- a/lib/whois/parsers/whois.tld.ee.rb
+++ b/lib/whois/parsers/whois.tld.ee.rb
@@ -63,19 +63,19 @@ module Whois
 
       property_supported :created_on do
         if content_for_scanner =~ /registered:\s+(.+?)\n/
-          Time.parse($1)
+          parse_time($1)
         end
       end
 
       property_supported :updated_on do
         if content_for_scanner =~ /changed:\s+(.+?)\n/
-          Time.parse($1)
+          parse_time($1)
         end
       end
 
       property_supported :expires_on do
         if content_for_scanner =~ /expire:\s+(.+?)\n/
-          Time.parse($1)
+          parse_time($1)
         end
       end
 
@@ -123,7 +123,7 @@ module Whois
               type:       type,
               name:       Array.wrap(hash['name'])[i],
               email:      Array.wrap(hash['email'])[i],
-              updated_on: Time.parse(Array.wrap(hash['changed'])[i])
+              updated_on: parse_time(Array.wrap(hash['changed'])[i])
             )
           end
         end

--- a/lib/whois/parsers/whois.twnic.net.tw.rb
+++ b/lib/whois/parsers/whois.twnic.net.tw.rb
@@ -45,7 +45,7 @@ module Whois
 
       property_supported :created_on do
         if content_for_scanner =~ /Record created on ([^ ]+) .+\n/
-          Time.parse($1)
+          parse_time($1)
         end
       end
 
@@ -53,7 +53,7 @@ module Whois
 
       property_supported :expires_on do
         if content_for_scanner =~ /Record expires on ([^ ]+) .+\n/
-          Time.parse($1)
+          parse_time($1)
         end
       end
 

--- a/lib/whois/parsers/whois.ua.rb
+++ b/lib/whois/parsers/whois.ua.rb
@@ -41,19 +41,19 @@ module Whois
 
         def created_on
           if content =~ /created:\s+(.+)\n/
-            Time.parse($1)
+            Base.parse_time($1)
           end
         end
 
         def updated_on
           if content =~ /modified:\s+(.+)\n/
-            Time.parse($1)
+            Base.parse_time($1)
           end
         end
 
         def expires_on
           if content =~ /expires:\s+(.+)\n/
-            Time.parse($1)
+            Base.parse_time($1)
           end
         end
 
@@ -81,7 +81,7 @@ module Whois
               phone:        textblock.slice(/phone:\s+(.+)\n/, 1),
               fax:          textblock.slice(/fax:\s+(.+)\n/, 1),
               email:        textblock.slice(/e-mail:\s+(.+)\n/, 1),
-              created_on:   Time.parse(textblock.slice(/created:\s+(.+)\n/, 1))
+              created_on:   Base.parse_time(textblock.slice(/created:\s+(.+)\n/, 1))
             )
           end
         end
@@ -111,21 +111,21 @@ module Whois
         def created_on
           if content =~ /created:\s+(.+)\n/
             time = $1.split(" ").last
-            Time.parse(time)
+            Base.parse_time(time)
           end
         end
 
         def updated_on
           if content =~ /changed:\s+(.+)\n/
             time = $1.split(" ").last
-            Time.parse(time)
+            Base.parse_time(time)
           end
         end
 
         def expires_on
           if content =~ /status:\s+(.+)\n/
             time = $1.split(" ").last
-            Time.parse(time)
+            Base.parse_time(time)
           end
         end
 
@@ -157,7 +157,7 @@ module Whois
               phone:        textblock.slice(/phone:\s+(.+)\n/, 1),
               fax:          textblock.slice(/fax-no:\s+(.+)\n/, 1),
               email:        textblock.slice(/e-mail:\s+(.+)\n/, 1),
-              updated_on:   (Time.parse($1.split(" ").last) if textblock =~ /changed:\s+(.+)\n/)
+              updated_on:   (Base.parse_time($1.split(" ").last) if textblock =~ /changed:\s+(.+)\n/)
             )
           end
         end

--- a/lib/whois/parsers/whois.uniregistry.net.rb
+++ b/lib/whois/parsers/whois.uniregistry.net.rb
@@ -55,10 +55,6 @@ module Whois
         contact
       end
 
-      def parse_time(value)
-        Time.parse(value).change(usec: 0)
-      end
-
     end
 
   end

--- a/lib/whois/parsers/whois.usp.ac.fj.rb
+++ b/lib/whois/parsers/whois.usp.ac.fj.rb
@@ -52,7 +52,7 @@ module Whois
 
       property_supported :expires_on do
         if content_for_scanner =~ /Expires:\s+(.*)\n/
-          Time.parse($1)
+          parse_time($1)
         end
       end
 

--- a/lib/whois/parsers/whois.verisign-grs.com.rb
+++ b/lib/whois/parsers/whois.verisign-grs.com.rb
@@ -21,7 +21,7 @@ module Whois
     class WhoisVerisignGrsCom < BaseVerisign
 
       property_supported :expires_on do
-        node("Expiration Date") { |value| Time.parse(value) }
+        node("Expiration Date") { |value| parse_time(value) }
       end
 
 

--- a/lib/whois/parsers/whois.website.ws.rb
+++ b/lib/whois/parsers/whois.website.ws.rb
@@ -43,19 +43,19 @@ module Whois
 
       property_supported :created_on do
         if content_for_scanner =~ /\s+Domain Created:\s+(.*)\n/
-          Time.parse($1)
+          parse_time($1)
         end
       end
 
       property_supported :updated_on do
         if content_for_scanner =~ /\s+Domain Last Updated:\s+(.*)\n/
-          Time.parse($1)
+          parse_time($1)
         end
       end
 
       property_supported :expires_on do
         if content_for_scanner =~ /\s+Domain Currently Expires:\s+(.*)\n/
-          Time.parse($1)
+          parse_time($1)
         end
       end
 

--- a/lib/whois/parsers/whois.yoursrs.com.rb
+++ b/lib/whois/parsers/whois.yoursrs.com.rb
@@ -53,7 +53,7 @@ module Whois
 
       property_supported :updated_on do
         node("Last Updated On") do |value|
-          parse_time(value) unless value.empty?
+          parse_time(value)
         end
       end
 

--- a/lib/whois/parsers/whois.yoursrs.com.rb
+++ b/lib/whois/parsers/whois.yoursrs.com.rb
@@ -47,19 +47,19 @@ module Whois
 
       property_supported :created_on do
         node("Created On") do |value|
-          Time.parse(value)
+          parse_time(value)
         end
       end
 
       property_supported :updated_on do
         node("Last Updated On") do |value|
-          Time.parse(value) unless value.empty?
+          parse_time(value) unless value.empty?
         end
       end
 
       property_supported :expires_on do
         node("Expiration Date") do |value|
-          Time.parse(value)
+          parse_time(value)
         end
       end
 

--- a/lib/whois/parsers/whois.za.net.rb
+++ b/lib/whois/parsers/whois.za.net.rb
@@ -45,13 +45,13 @@ module Whois
 
       property_supported :created_on do
         if content_for_scanner =~ /Record Created\s+:\s+(.*)\n/
-          Time.parse($1)
+          parse_time($1)
         end
       end
 
       property_supported :updated_on do
         if content_for_scanner =~ /Record Last Updated\s+:\s+(.*)\n/
-          Time.parse($1)
+          parse_time($1)
         end
       end
 

--- a/lib/whois/parsers/whois.za.org.rb
+++ b/lib/whois/parsers/whois.za.org.rb
@@ -45,13 +45,13 @@ module Whois
 
       property_supported :created_on do
         if content_for_scanner =~ /Record Created\s+:\s+(.*)\n/
-          Time.parse($1)
+          parse_time($1)
         end
       end
 
       property_supported :updated_on do
         if content_for_scanner =~ /Record Last Updated\s+:\s+(.*)\n/
-          Time.parse($1)
+          parse_time($1)
         end
       end
 

--- a/spec/whois/parsers/base_spec.rb
+++ b/spec/whois/parsers/base_spec.rb
@@ -35,6 +35,22 @@ describe Whois::Parsers::Base do
     end
   end
 
+  describe ".parse_time" do
+    it "returns a parsed timestamp" do
+      expect(described_class.parse_time("1970-01-01T00:00:00Z")).to eq(Time.at(0))
+    end
+
+    it "removes microseconds on parsed timestamps" do
+      expect(described_class.parse_time("1970-01-01T00:00:00.123Z")).to eq(Time.at(0))
+    end
+
+    it "returns nil for invalid input" do
+      expect(described_class.parse_time(nil)).to be_nil
+      expect(described_class.parse_time("null")).to be_nil
+      expect(described_class.parse_time("")).to be_nil
+    end
+  end
+
 
   describe "#initialize" do
     it "requires a part" do

--- a/spec/whois/parsers/responses/whois.nic.ci/ci/status_registered_spec.rb
+++ b/spec/whois/parsers/responses/whois.nic.ci/ci/status_registered_spec.rb
@@ -39,7 +39,7 @@ describe Whois::Parsers::WhoisNicCi, "status_registered.expected" do
   describe "#created_on" do
     it do
       expect(subject.created_on).to be_a(Time)
-      expect(subject.created_on).to eq(Time.parse("2006-01-27 11:14:47.77"))
+      expect(subject.created_on).to eq(Time.parse("2006-01-27 11:14:47"))
     end
   end
   describe "#updated_on" do
@@ -50,7 +50,7 @@ describe Whois::Parsers::WhoisNicCi, "status_registered.expected" do
   describe "#expires_on" do
     it do
       expect(subject.expires_on).to be_a(Time)
-      expect(subject.expires_on).to eq(Time.parse("2014-02-14 11:14:47.77"))
+      expect(subject.expires_on).to eq(Time.parse("2014-02-14 11:14:47"))
     end
   end
   describe "#nameservers" do

--- a/spec/whois/parsers/responses/whois.nic.lv/lv/status_registered_spec.rb
+++ b/spec/whois/parsers/responses/whois.nic.lv/lv/status_registered_spec.rb
@@ -44,7 +44,7 @@ describe Whois::Parsers::WhoisNicLv, "status_registered.expected" do
   describe "#updated_on" do
     it do
       expect(subject.updated_on).to be_a(Time)
-      expect(subject.updated_on).to eq(Time.parse("2013-07-08T19:35:53.187695+03:00"))
+      expect(subject.updated_on).to eq(Time.parse("2013-07-08T19:35:53+03:00"))
     end
   end
   describe "#expires_on" do

--- a/spec/whois/parsers/responses/whois.nic.sn/sn/status_registered_spec.rb
+++ b/spec/whois/parsers/responses/whois.nic.sn/sn/status_registered_spec.rb
@@ -54,7 +54,7 @@ describe Whois::Parsers::WhoisNicSn, "status_registered.expected" do
   describe "#created_on" do
     it do
       expect(subject.created_on).to be_a(Time)
-      expect(subject.created_on).to eq(Time.parse("2008-05-08 17:59:38.43"))
+      expect(subject.created_on).to eq(Time.parse("2008-05-08 17:59:38"))
     end
   end
   describe "#updated_on" do


### PR DESCRIPTION
Port of https://github.com/weppos/whois/pull/459.

**Original description**

> Ruby's `Time.parse` can raise `ArgumentError` if the input cannot be parsed, as stated in its [documentation](https://github.com/ruby/ruby/blob/36326ceb22d114ec75675806d2c434f89ad417d1/lib/time.rb#L307-L367).
>
> Several parsers attempt to handle this in different ways but others accidentally let `ArgumentError` bubble up (as seen in https://github.com/weppos/whois/issues/345 and in production at Shopify).
> 
> **Changes**
> 
> - Introduces `Whois::Record::Parser::Base.parse_time` and `#parse_time` helper functions which
>   - handle empty or invalid input
>   - standardize the handling of microseconds
> - Replaces all instances of `Time.parse` with `parse_time`
> - Removes various custom helpers and validation rendered superfluous by the new helpers
>
> The only changes made to the test suite were to remove microsecond precision from sample timestamps.