### PR TITLE
No longer expect a Registrar ID from whois.audns.net.au

### DIFF
--- a/lib/whois/parsers/whois.audns.net.au.rb
+++ b/lib/whois/parsers/whois.audns.net.au.rb
@@ -63,10 +63,10 @@ module Whois
 
 
       property_supported :registrar do
-        node("Registrar ID") do |str|
+        node("Registrar Name") do |str|
           Parser::Registrar.new(
-            :id   => str,
-            :name => node("Registrar Name")
+            :id   => str, # Registrar ID is no longer returned, use the name instead
+            :name => str
           )
         end
       end

--- a/lib/whois/parsers/whois.audns.net.au.rb
+++ b/lib/whois/parsers/whois.audns.net.au.rb
@@ -65,7 +65,6 @@ module Whois
       property_supported :registrar do
         node("Registrar Name") do |str|
           Parser::Registrar.new(
-            :id   => str, # Registrar ID is no longer returned, use the name instead
             :name => str
           )
         end

--- a/spec/fixtures/responses/whois.audns.net.au/au/status_registered.expected
+++ b/spec/fixtures/responses/whois.audns.net.au/au/status_registered.expected
@@ -32,7 +32,6 @@
 
 #registrar
   %s %CLASS{registrar}
-  %s.id           == "MARKMONITOR"
   %s.name         == "MarkMonitor Inc."
   %s.organization == nil
   %s.url          == nil

--- a/spec/fixtures/responses/whois.audns.net.au/au/status_registered.expected
+++ b/spec/fixtures/responses/whois.audns.net.au/au/status_registered.expected
@@ -24,7 +24,7 @@
 
 #updated_on
   %s %CLASS{time}
-  %s %TIME{2013-06-05 04:03:08 UTC}
+  %s %TIME{2014-11-05 10:35:59 UTC}
 
 #expires_on
   %s %ERROR{AttributeNotSupported}

--- a/spec/fixtures/responses/whois.audns.net.au/au/status_registered.txt
+++ b/spec/fixtures/responses/whois.audns.net.au/au/status_registered.txt
@@ -1,10 +1,10 @@
 Domain Name:                     google.com.au
-Last Modified:                   05-Jun-2013 04:03:08 UTC
-Registrar Name:                  MarkMonitor Inc.
+Last Modified:                   05-Nov-2014 10:35:59 UTC
 Status:                          clientDeleteProhibited
 Status:                          clientUpdateProhibited
 Status:                          serverDeleteProhibited (Protected by .auLOCKDOWN)
 Status:                          serverUpdateProhibited (Protected by .auLOCKDOWN)
+Registrar Name:                  MarkMonitor Inc.
 
 Registrant:                      Google INC
 Eligibility Type:                Trademark Owner
@@ -23,3 +23,4 @@ Name Server:                     ns1.google.com
 Name Server:                     ns2.google.com
 Name Server:                     ns3.google.com
 Name Server:                     ns4.google.com
+DNSSEC:                          unsigned

--- a/spec/fixtures/responses/whois.audns.net.au/au/status_registered.txt
+++ b/spec/fixtures/responses/whois.audns.net.au/au/status_registered.txt
@@ -1,6 +1,5 @@
 Domain Name:                     google.com.au
 Last Modified:                   05-Jun-2013 04:03:08 UTC
-Registrar ID:                    MARKMONITOR
 Registrar Name:                  MarkMonitor Inc.
 Status:                          clientDeleteProhibited
 Status:                          clientUpdateProhibited

--- a/spec/whois/parsers/responses/whois.audns.net.au/au/status_registered_spec.rb
+++ b/spec/whois/parsers/responses/whois.audns.net.au/au/status_registered_spec.rb
@@ -59,7 +59,7 @@ describe Whois::Parsers::WhoisAudnsNetAu, "status_registered.expected" do
   describe "#updated_on" do
     it do
       expect(subject.updated_on).to be_a(Time)
-      expect(subject.updated_on).to eq(Time.parse("2013-06-05 04:03:08 UTC"))
+      expect(subject.updated_on).to eq(Time.parse("2014-11-05 10:35:59 UTC"))
     end
   end
   describe "#expires_on" do
@@ -70,7 +70,6 @@ describe Whois::Parsers::WhoisAudnsNetAu, "status_registered.expected" do
   describe "#registrar" do
     it do
       expect(subject.registrar).to be_a(Whois::Parser::Registrar)
-      expect(subject.registrar.id).to eq("MarkMonitor Inc.") # Registrar ID is no longer returned, use the name instead
       expect(subject.registrar.name).to eq("MarkMonitor Inc.")
       expect(subject.registrar.organization).to eq(nil)
       expect(subject.registrar.url).to eq(nil)

--- a/spec/whois/parsers/responses/whois.audns.net.au/au/status_registered_spec.rb
+++ b/spec/whois/parsers/responses/whois.audns.net.au/au/status_registered_spec.rb
@@ -70,7 +70,7 @@ describe Whois::Parsers::WhoisAudnsNetAu, "status_registered.expected" do
   describe "#registrar" do
     it do
       expect(subject.registrar).to be_a(Whois::Parser::Registrar)
-      expect(subject.registrar.id).to eq("MARKMONITOR")
+      expect(subject.registrar.id).to eq("MarkMonitor Inc.") # Registrar ID is no longer returned, use the name instead
       expect(subject.registrar.name).to eq("MarkMonitor Inc.")
       expect(subject.registrar.organization).to eq(nil)
       expect(subject.registrar.url).to eq(nil)


### PR DESCRIPTION
Regarding #20 

To minimise breakage in apps using this gem I thought it would be best to populate the registrar ID attribute with the registrar name instead of removing it. Happy to revise if you'd prefer otherwise.