### PR TITLE
Use respond_to_missing instead of respond_to

### DIFF
--- a/lib/whois/parser_extensions/whois_record.rb
+++ b/lib/whois/parser_extensions/whois_record.rb
@@ -15,7 +15,7 @@ module Whois
       # for {Parser::PROPERTIES} and {Parser::METHODS}.
       #
       # @return [Boolean]
-      def respond_to?(symbol, include_private = false)
+      def respond_to_missing?(symbol, include_private = false)
         respond_to_parser_method?(symbol) || super
       end
 

--- a/lib/whois/parser_extensions/whois_record.rb
+++ b/lib/whois/parser_extensions/whois_record.rb
@@ -168,8 +168,16 @@ module Whois
 
       # @api private
       def respond_to_parser_method?(symbol)
-        name = symbol.to_s =~ /\?$/ ? symbol.to_s[0..-2] : symbol
-        Parser::PROPERTIES.include?(name.to_sym) || Parser::METHODS.include?(name.to_sym)
+        Parser::PROPERTIES.include?(symbol) ||
+          Parser::METHODS.include?(symbol) ||
+          respond_to_question_method?(symbol)
+      end
+
+      def respond_to_question_method?(symbol)
+        return false unless symbol.to_s =~ /([a-z_]+)\?/
+        symbol = $1.to_sym
+        Parser::PROPERTIES.include?(symbol) ||
+            Parser::METHODS.include?(symbol)
       end
 
       # Delegates all method calls to the internal parser.

--- a/spec/whois/parser_extensions/record_spec.rb
+++ b/spec/whois/parser_extensions/record_spec.rb
@@ -20,10 +20,8 @@ describe Whois::Record do
     end
 
     after(:all) do
-      Whois::Parser::PROPERTIES.clear
-      Whois::Parser::PROPERTIES.push(*@_properties)
-      Whois::Parser::METHODS.clear
-      Whois::Parser::METHODS.push(*@_methods)
+      Whois::Parser::PROPERTIES.replace(@_properties)
+      Whois::Parser::METHODS.replace(@_methods)
     end
 
     it "returns true if method is in self" do

--- a/spec/whois/parser_extensions/record_spec.rb
+++ b/spec/whois/parser_extensions/record_spec.rb
@@ -40,8 +40,8 @@ describe Whois::Record do
     end
 
     it "returns true if method is a property?" do
-      Whois::Parser::PROPERTIES << :test_property
-      expect(subject.respond_to?(:test_property?)).to be_truthy
+      Whois::Parser::PROPERTIES << :test_property_b
+      expect(subject.respond_to?(:test_property_b?)).to be_truthy
     end
 
     it "returns true if method is a method" do
@@ -49,9 +49,9 @@ describe Whois::Record do
       expect(subject.respond_to?(:test_method)).to be_truthy
     end
 
-    it "returns true if method is a method" do
-      Whois::Parser::METHODS << :test_method
-      expect(subject.respond_to?(:test_method?)).to be_truthy
+    it "returns true if method is a method?" do
+      Whois::Parser::METHODS << :test_method_b
+      expect(subject.respond_to?(:test_method_b?)).to be_truthy
     end
   end
 

--- a/spec/whois/parser_extensions/record_spec.rb
+++ b/spec/whois/parser_extensions/record_spec.rb
@@ -44,6 +44,11 @@ describe Whois::Record do
       expect(subject.respond_to?(:test_property_b?)).to be_truthy
     end
 
+    it "returns true if method? is a property?" do
+      Whois::Parser::PROPERTIES << :test_property_c?
+      expect(subject.respond_to?(:test_property_c?)).to be_truthy
+    end
+
     it "returns true if method is a method" do
       Whois::Parser::METHODS << :test_method
       expect(subject.respond_to?(:test_method)).to be_truthy
@@ -52,6 +57,11 @@ describe Whois::Record do
     it "returns true if method is a method?" do
       Whois::Parser::METHODS << :test_method_b
       expect(subject.respond_to?(:test_method_b?)).to be_truthy
+    end
+
+    it "returns true if method? is a method?" do
+      Whois::Parser::METHODS << :test_method_c?
+      expect(subject.respond_to?(:test_method_c?)).to be_truthy
     end
   end
 

--- a/spec/whois/parser_extensions/record_spec.rb
+++ b/spec/whois/parser_extensions/record_spec.rb
@@ -63,6 +63,55 @@ describe Whois::Record do
     end
   end
 
+  describe "#method" do
+    before(:all) do
+      @_properties  = Whois::Parser::PROPERTIES.dup
+      @_methods     = Whois::Parser::METHODS.dup
+    end
+
+    after(:all) do
+      Whois::Parser::PROPERTIES.replace(@_properties)
+      Whois::Parser::METHODS.replace(@_methods)
+    end
+
+    it "returns true if method is in self" do
+      expect(subject.method(:to_s)).to be_instance_of Method
+    end
+
+    it "returns true if method is in hierarchy" do
+      expect(subject.method(:nil?)).to be_instance_of Method
+    end
+
+    it "returns true if method is a property" do
+      Whois::Parser::PROPERTIES << :test_md_property
+      expect(subject.method(:test_md_property)).to be_instance_of Method
+    end
+
+    it "returns true if method is a property?" do
+      Whois::Parser::PROPERTIES << :test_md_property_b
+      expect(subject.method(:test_md_property_b?)).to be_instance_of Method
+    end
+
+    it "returns true if method? is a property?" do
+      Whois::Parser::PROPERTIES << :test_md_property_c?
+      expect(subject.method(:test_md_property_c?)).to be_instance_of Method
+    end
+
+    it "returns true if method is a method" do
+      Whois::Parser::METHODS << :test_md_method
+      expect(subject.method(:test_md_method)).to be_instance_of Method
+    end
+
+    it "returns true if method is a method?" do
+      Whois::Parser::METHODS << :test_md_method_b
+      expect(subject.method(:test_md_method_b?)).to be_instance_of Method
+    end
+
+    it "returns true if method? is a method?" do
+      Whois::Parser::METHODS << :test_md_method_c?
+      expect(subject.method(:test_md_method_c?)).to be_instance_of Method
+    end
+  end
 
   describe "#parser" do
     it "returns a Parser" do


### PR DESCRIPTION
Best to override `respond_to_missing?` instead of `respond_to?`. It's faster and allows accessing `method`.

Builds on #28 