### PR TITLE
Avoid be_truthy and be_falsey

### DIFF
--- a/lib/whois/parser_extensions/whois_record.rb
+++ b/lib/whois/parser_extensions/whois_record.rb
@@ -15,7 +15,7 @@ module Whois
       # for {Parser::PROPERTIES} and {Parser::METHODS}.
       #
       # @return [Boolean]
-      def respond_to?(symbol, include_private = false)
+      def respond_to_missing?(symbol, include_private = false)
         respond_to_parser_method?(symbol) || super
       end
 

--- a/lib/whois/parser_extensions/whois_record.rb
+++ b/lib/whois/parser_extensions/whois_record.rb
@@ -168,8 +168,16 @@ module Whois
 
       # @api private
       def respond_to_parser_method?(symbol)
-        name = symbol.to_s =~ /\?$/ ? symbol.to_s[0..-2] : symbol
-        Parser::PROPERTIES.include?(name.to_sym) || Parser::METHODS.include?(name.to_sym)
+        Parser::PROPERTIES.include?(symbol) ||
+          Parser::METHODS.include?(symbol) ||
+          respond_to_question_method?(symbol)
+      end
+
+      def respond_to_question_method?(symbol)
+        return false unless symbol.to_s =~ /([a-z_]+)\?/
+        symbol = $1.to_sym
+        Parser::PROPERTIES.include?(symbol) ||
+            Parser::METHODS.include?(symbol)
       end
 
       # Delegates all method calls to the internal parser.

--- a/spec/integration/whois_spec.rb
+++ b/spec/integration/whois_spec.rb
@@ -15,8 +15,8 @@ describe Whois do
         record = Whois.lookup("example.it")
 
         expect(record).to be_a(Whois::Record)
-        expect(record.available?).to be_truthy
-        expect(record.registered?).to be_falsey
+        expect(record.available?).to eq(true)
+        expect(record.registered?).to eq(false)
 
         expect(record.parser).to be_a(Whois::Parser)
         expect(record.parser.parsers.first).to be_a(Whois::Parsers::WhoisNicIt)

--- a/spec/support/example/parser_example_group.rb
+++ b/spec/support/example/parser_example_group.rb
@@ -13,10 +13,10 @@ RSpec::Matchers.define :cache_property do |property|
       @cached_properties
     end
 
-    expect(cache.key?(property)).to be_falsey
+    expect(cache.key?(property)).to eq(false)
     value = instance.send(property)
 
-    expect(cache.key?(property)).to be_truthy
+    expect(cache.key?(property)).to eq(true)
     expect(cache[property]).to eq(value)
 
     true

--- a/spec/whois/parser_extensions/record_spec.rb
+++ b/spec/whois/parser_extensions/record_spec.rb
@@ -20,10 +20,8 @@ describe Whois::Record do
     end
 
     after(:all) do
-      Whois::Parser::PROPERTIES.clear
-      Whois::Parser::PROPERTIES.push(*@_properties)
-      Whois::Parser::METHODS.clear
-      Whois::Parser::METHODS.push(*@_methods)
+      Whois::Parser::PROPERTIES.replace(@_properties)
+      Whois::Parser::METHODS.replace(@_methods)
     end
 
     it "returns true if method is in self" do

--- a/spec/whois/parser_extensions/record_spec.rb
+++ b/spec/whois/parser_extensions/record_spec.rb
@@ -40,8 +40,8 @@ describe Whois::Record do
     end
 
     it "returns true if method is a property?" do
-      Whois::Parser::PROPERTIES << :test_property
-      expect(subject.respond_to?(:test_property?)).to be_truthy
+      Whois::Parser::PROPERTIES << :test_property_b
+      expect(subject.respond_to?(:test_property_b?)).to be_truthy
     end
 
     it "returns true if method is a method" do
@@ -49,9 +49,9 @@ describe Whois::Record do
       expect(subject.respond_to?(:test_method)).to be_truthy
     end
 
-    it "returns true if method is a method" do
-      Whois::Parser::METHODS << :test_method
-      expect(subject.respond_to?(:test_method?)).to be_truthy
+    it "returns true if method is a method?" do
+      Whois::Parser::METHODS << :test_method_b
+      expect(subject.respond_to?(:test_method_b?)).to be_truthy
     end
   end
 

--- a/spec/whois/parser_extensions/record_spec.rb
+++ b/spec/whois/parser_extensions/record_spec.rb
@@ -25,41 +25,41 @@ describe Whois::Record do
     end
 
     it "returns true if method is in self" do
-      expect(subject.respond_to?(:to_s)).to be_truthy
+      expect(subject.respond_to?(:to_s)).to eq(true)
     end
 
     it "returns true if method is in hierarchy" do
-      expect(subject.respond_to?(:nil?)).to be_truthy
+      expect(subject.respond_to?(:nil?)).to eq(true)
     end
 
     it "returns true if method is a property" do
       Whois::Parser::PROPERTIES << :test_property
-      expect(subject.respond_to?(:test_property)).to be_truthy
+      expect(subject.respond_to?(:test_property)).to eq(true)
     end
 
     it "returns true if method is a property?" do
       Whois::Parser::PROPERTIES << :test_property_b
-      expect(subject.respond_to?(:test_property_b?)).to be_truthy
+      expect(subject.respond_to?(:test_property_b?)).to eq(true)
     end
 
     it "returns true if method? is a property?" do
       Whois::Parser::PROPERTIES << :test_property_c?
-      expect(subject.respond_to?(:test_property_c?)).to be_truthy
+      expect(subject.respond_to?(:test_property_c?)).to eq(true)
     end
 
     it "returns true if method is a method" do
       Whois::Parser::METHODS << :test_method
-      expect(subject.respond_to?(:test_method)).to be_truthy
+      expect(subject.respond_to?(:test_method)).to eq(true)
     end
 
     it "returns true if method is a method?" do
       Whois::Parser::METHODS << :test_method_b
-      expect(subject.respond_to?(:test_method_b?)).to be_truthy
+      expect(subject.respond_to?(:test_method_b?)).to eq(true)
     end
 
     it "returns true if method? is a method?" do
       Whois::Parser::METHODS << :test_method_c?
-      expect(subject.respond_to?(:test_method_c?)).to be_truthy
+      expect(subject.respond_to?(:test_method_c?)).to eq(true)
     end
   end
 
@@ -227,7 +227,7 @@ describe Whois::Record do
 
     it "returns true if self and other references the same object" do
       instance = described_class.new(nil, [])
-      expect(instance.unchanged?(instance)).to be_truthy
+      expect(instance.unchanged?(instance)).to eq(true)
     end
 
     it "delegates to #parser if self and other references different objects" do

--- a/spec/whois/parser_extensions/record_spec.rb
+++ b/spec/whois/parser_extensions/record_spec.rb
@@ -44,6 +44,11 @@ describe Whois::Record do
       expect(subject.respond_to?(:test_property_b?)).to be_truthy
     end
 
+    it "returns true if method? is a property?" do
+      Whois::Parser::PROPERTIES << :test_property_c?
+      expect(subject.respond_to?(:test_property_c?)).to be_truthy
+    end
+
     it "returns true if method is a method" do
       Whois::Parser::METHODS << :test_method
       expect(subject.respond_to?(:test_method)).to be_truthy
@@ -52,6 +57,11 @@ describe Whois::Record do
     it "returns true if method is a method?" do
       Whois::Parser::METHODS << :test_method_b
       expect(subject.respond_to?(:test_method_b?)).to be_truthy
+    end
+
+    it "returns true if method? is a method?" do
+      Whois::Parser::METHODS << :test_method_c?
+      expect(subject.respond_to?(:test_method_c?)).to be_truthy
     end
   end
 

--- a/spec/whois/parser_extensions/record_spec.rb
+++ b/spec/whois/parser_extensions/record_spec.rb
@@ -63,6 +63,55 @@ describe Whois::Record do
     end
   end
 
+  describe "#method" do
+    before(:all) do
+      @_properties  = Whois::Parser::PROPERTIES.dup
+      @_methods     = Whois::Parser::METHODS.dup
+    end
+
+    after(:all) do
+      Whois::Parser::PROPERTIES.replace(@_properties)
+      Whois::Parser::METHODS.replace(@_methods)
+    end
+
+    it "returns true if method is in self" do
+      expect(subject.method(:to_s)).to be_instance_of Method
+    end
+
+    it "returns true if method is in hierarchy" do
+      expect(subject.method(:nil?)).to be_instance_of Method
+    end
+
+    it "returns true if method is a property" do
+      Whois::Parser::PROPERTIES << :test_md_property
+      expect(subject.method(:test_md_property)).to be_instance_of Method
+    end
+
+    it "returns true if method is a property?" do
+      Whois::Parser::PROPERTIES << :test_md_property_b
+      expect(subject.method(:test_md_property_b?)).to be_instance_of Method
+    end
+
+    it "returns true if method? is a property?" do
+      Whois::Parser::PROPERTIES << :test_md_property_c?
+      expect(subject.method(:test_md_property_c?)).to be_instance_of Method
+    end
+
+    it "returns true if method is a method" do
+      Whois::Parser::METHODS << :test_md_method
+      expect(subject.method(:test_md_method)).to be_instance_of Method
+    end
+
+    it "returns true if method is a method?" do
+      Whois::Parser::METHODS << :test_md_method_b
+      expect(subject.method(:test_md_method_b?)).to be_instance_of Method
+    end
+
+    it "returns true if method? is a method?" do
+      Whois::Parser::METHODS << :test_md_method_c?
+      expect(subject.method(:test_md_method_c?)).to be_instance_of Method
+    end
+  end
 
   describe "#parser" do
     it "returns a Parser" do

--- a/spec/whois/parser_extensions/whois_spec.rb
+++ b/spec/whois/parser_extensions/whois_spec.rb
@@ -17,7 +17,7 @@ describe Whois do
         Whois::Server.define(:tld, ".test", "parser.test")
         expect_any_instance_of(Whois::Server::Adapters::Standard).to receive(:query_the_socket).with("example.test", "parser.test").and_return("1 == 1")
 
-        expect(Whois.available?("example.test")).to be_truthy
+        expect(Whois.available?("example.test")).to eq(true)
       end
     end
 
@@ -26,7 +26,7 @@ describe Whois do
         Whois::Server.define(:tld, ".test", "parser.test")
         expect_any_instance_of(Whois::Server::Adapters::Standard).to receive(:query_the_socket).with("example.test", "parser.test").and_return("1 == 2")
 
-        expect(Whois.available?("example.test")).to be_falsey
+        expect(Whois.available?("example.test")).to eq(false)
       end
     end
 
@@ -46,7 +46,7 @@ describe Whois do
         Whois::Server.define(:tld, ".test", "parser.test")
         expect_any_instance_of(Whois::Server::Adapters::Standard).to receive(:query_the_socket).with("example.test", "parser.test").and_return("1 == 1")
 
-        expect(Whois.registered?("example.test")).to be_falsey
+        expect(Whois.registered?("example.test")).to eq(false)
       end
     end
 
@@ -55,7 +55,7 @@ describe Whois do
         Whois::Server.define(:tld, ".test", "parser.test")
         expect_any_instance_of(Whois::Server::Adapters::Standard).to receive(:query_the_socket).with("example.test", "parser.test").and_return("1 == 2")
 
-        expect(Whois.registered?("example.test")).to be_truthy
+        expect(Whois.registered?("example.test")).to eq(true)
       end
     end
 

--- a/spec/whois/parser_spec.rb
+++ b/spec/whois/parser_spec.rb
@@ -82,31 +82,31 @@ describe Whois::Parser do
     end
 
     it "returns true if method is in self" do
-      expect(subject.respond_to?(:to_s)).to be_truthy
+      expect(subject.respond_to?(:to_s)).to eq(true)
     end
 
     it "returns true if method is in hierarchy" do
-      expect(subject.respond_to?(:nil?)).to be_truthy
+      expect(subject.respond_to?(:nil?)).to eq(true)
     end
 
     it "returns true if method is a property" do
       Whois::Parser::PROPERTIES << :test_property
-      expect(subject.respond_to?(:test_property)).to be_truthy
+      expect(subject.respond_to?(:test_property)).to eq(true)
     end
 
     it "returns false if method is a property?" do
       Whois::Parser::PROPERTIES << :test_property
-      expect(subject.respond_to?(:test_property?)).to be_falsey
+      expect(subject.respond_to?(:test_property?)).to eq(false)
     end
 
     it "returns true if method is a method" do
       Whois::Parser::METHODS << :test_method
-      expect(subject.respond_to?(:test_method)).to be_truthy
+      expect(subject.respond_to?(:test_method)).to eq(true)
     end
 
     it "returns false if method is a method" do
       Whois::Parser::METHODS << :test_method
-      expect(subject.respond_to?(:test_method?)).to be_falsey
+      expect(subject.respond_to?(:test_method?)).to eq(false)
     end
   end
 
@@ -232,27 +232,27 @@ describe Whois::Parser do
   describe "#property_any_supported?" do
     it "returns false when 0 parts" do
       record = Whois::Record.new(nil, [])
-      expect(described_class.new(record).property_any_supported?(:disclaimer)).to be_falsey
+      expect(described_class.new(record).property_any_supported?(:disclaimer)).to eq(false)
     end
 
     it "returns true when 1 part supported" do
       record = Whois::Record.new(nil, [Whois::Record::Part.new(host: "whois.nic.it")])
-      expect(described_class.new(record).property_any_supported?(:disclaimer)).to be_truthy
+      expect(described_class.new(record).property_any_supported?(:disclaimer)).to eq(true)
     end
 
     it "returns false when 1 part supported" do
       record = Whois::Record.new(nil, [Whois::Record::Part.new(host: "missing.nic.it")])
-      expect(described_class.new(record).property_any_supported?(:disclaimer)).to be_falsey
+      expect(described_class.new(record).property_any_supported?(:disclaimer)).to eq(false)
     end
 
     it "returns true when 2 parts" do
       record = Whois::Record.new(nil, [Whois::Record::Part.new(host: "whois.verisign-grs.com"), Whois::Record::Part.new(host: "whois.nic.it")])
-      expect(described_class.new(record).property_any_supported?(:disclaimer)).to be_truthy
+      expect(described_class.new(record).property_any_supported?(:disclaimer)).to eq(true)
     end
 
     it "returns true when 1 part supported 1 part not supported" do
       record = Whois::Record.new(nil, [Whois::Record::Part.new(host: "missing.nic.it"), Whois::Record::Part.new(host: "whois.nic.it")])
-      expect(described_class.new(record).property_any_supported?(:disclaimer)).to be_truthy
+      expect(described_class.new(record).property_any_supported?(:disclaimer)).to eq(true)
     end
   end
 
@@ -325,19 +325,19 @@ describe Whois::Parser do
 
     it "returns true if self and other references the same object" do
       instance = described_class.new(record)
-      expect(instance.unchanged?(instance)).to be_truthy
+      expect(instance.unchanged?(instance)).to eq(true)
     end
 
     it "returns false if parser and other.parser have different number of elements" do
       instance = described_class.new(Whois::Record.new(nil, []))
       other    = described_class.new(Whois::Record.new(nil, [Whois::Record::Part.new(body: "", host: "foo.example.test")]))
-      expect(instance.unchanged?(other)).to be_falsey
+      expect(instance.unchanged?(other)).to eq(false)
     end
 
     it "returns true if parsers and other.parsers have 0 elements" do
       instance = described_class.new(Whois::Record.new(nil, []))
       other    = described_class.new(Whois::Record.new(nil, []))
-      expect(instance.unchanged?(other)).to be_truthy
+      expect(instance.unchanged?(other)).to eq(true)
     end
 
 
@@ -345,14 +345,14 @@ describe Whois::Parser do
       instance = described_class.new(Whois::Record.new(nil, [Whois::Record::Part.new(body: "hello", host: "foo.example.test"), Whois::Record::Part.new(body: "hello", host: "bar.example.test")]))
       other    = described_class.new(Whois::Record.new(nil, [Whois::Record::Part.new(body: "hello", host: "foo.example.test"), Whois::Record::Part.new(body: "hello", host: "bar.example.test")]))
 
-      expect(instance.unchanged?(other)).to be_truthy
+      expect(instance.unchanged?(other)).to eq(true)
     end
 
     it "returns false unless every parser in self marches the corresponding parser in other" do
       instance = described_class.new(Whois::Record.new(nil, [Whois::Record::Part.new(body: "hello", host: "foo.example.test"), Whois::Record::Part.new(body: "world", host: "bar.example.test")]))
       other    = described_class.new(Whois::Record.new(nil, [Whois::Record::Part.new(body: "hello", host: "foo.example.test"), Whois::Record::Part.new(body: "baby!", host: "bar.example.test")]))
 
-      expect(instance.unchanged?(other)).to be_falsey
+      expect(instance.unchanged?(other)).to eq(false)
     end
   end
 

--- a/spec/whois/parsers/base_spec.rb
+++ b/spec/whois/parsers/base_spec.rb
@@ -22,16 +22,16 @@ describe Whois::Parsers::Base do
     it "returns false if the property is not supported" do
       koncrete = Class.new(described_class) do
       end
-      expect(koncrete.new(part).property_supported?(:disclaimer)).to be_falsey
-      expect(koncrete.new(part).respond_to?(:disclaimer)).to be_truthy
+      expect(koncrete.new(part).property_supported?(:disclaimer)).to eq(false)
+      expect(koncrete.new(part).respond_to?(:disclaimer)).to eq(true)
     end
 
     it "returns true if the property is supported" do
       koncrete = Class.new(described_class) do
         property_register(:disclaimer, Whois::Parser::PROPERTY_STATE_SUPPORTED) {}
       end
-      expect(koncrete.new(part).property_supported?(:disclaimer)).to be_truthy
-      expect(koncrete.new(part).respond_to?(:disclaimer)).to be_truthy
+      expect(koncrete.new(part).property_supported?(:disclaimer)).to eq(true)
+      expect(koncrete.new(part).respond_to?(:disclaimer)).to eq(true)
     end
   end
 
@@ -91,7 +91,7 @@ describe Whois::Parsers::Base do
     end
     it "does not call the method if the object does not respond to the method" do
       koncrete = Class.new(described_class).new(Whois::Record::Part.new)
-      expect(koncrete.is(:response_throttled?)).to be_falsey
+      expect(koncrete.is(:response_throttled?)).to eq(false)
     end
   end
 
@@ -139,19 +139,19 @@ describe Whois::Parsers::Base do
 
     it "returns true if self and other references the same object" do
       instance = described_class.new(part)
-      expect(instance.unchanged?(instance)).to be_truthy
+      expect(instance.unchanged?(instance)).to eq(true)
     end
 
     it "returns true if the content_for_scanner is the same" do
       instance = described_class.new(Whois::Record::Part.new(:body => "This is the\nresponse 1.", :host => "whois.example.test"))
       other = described_class.new(Whois::Record::Part.new(:body => "This is the\r\nresponse 1.", :host => "whois.example.test"))
-      expect(instance.unchanged?(other)).to be_truthy
+      expect(instance.unchanged?(other)).to eq(true)
     end
 
     it "returns false if the content_for_scanner is not the same" do
       instance = described_class.new(Whois::Record::Part.new(:body => "This is the response 1.", :host => "whois.example.test"))
       other = described_class.new(Whois::Record::Part.new(:body => "This is the response 2.", :host => "whois.example.test"))
-      expect(instance.unchanged?(other)).to be_falsey
+      expect(instance.unchanged?(other)).to eq(false)
     end
   end
 
@@ -178,7 +178,7 @@ describe Whois::Parsers::Base do
 
   describe "#response_incomplete?" do
     it "is undefined" do
-      expect(described_class.new(part).respond_to?(:response_incomplete?)).to be_falsey
+      expect(described_class.new(part).respond_to?(:response_incomplete?)).to eq(false)
     end
 
     # it "returns nil" do
@@ -188,13 +188,13 @@ describe Whois::Parsers::Base do
     #
     # it "is false" do
     #   i = described_class.new(part)
-    #   expect(i.response_incomplete?).to be_falsey
+    #   expect(i.response_incomplete?).to eq(false)
     # end
   end
 
   describe "#response_throttled?" do
     it "is undefined" do
-      expect(described_class.new(part).respond_to?(:response_throttled?)).to be_falsey
+      expect(described_class.new(part).respond_to?(:response_throttled?)).to eq(false)
     end
 
     # it "returns nil" do
@@ -204,13 +204,13 @@ describe Whois::Parsers::Base do
     #
     # it "is false" do
     #   i = described_class.new(part)
-    #   expect(i.response_throttled?).to be_falsey
+    #   expect(i.response_throttled?).to eq(false)
     # end
   end
 
   describe "#response_unavailable?" do
     it "is undefined" do
-      expect(described_class.new(part).respond_to?(:response_unavailable?)).to be_falsey
+      expect(described_class.new(part).respond_to?(:response_unavailable?)).to eq(false)
     end
 
     # it "returns nil" do
@@ -220,7 +220,7 @@ describe Whois::Parsers::Base do
     #
     # it "is false" do
     #   i = described_class.new(part)
-    #   expect(i.response_unavailable?).to be_falsey
+    #   expect(i.response_unavailable?).to eq(false)
     # end
   end
 

--- a/spec/whois/safe_record_spec.rb
+++ b/spec/whois/safe_record_spec.rb
@@ -38,31 +38,31 @@ describe Whois::SafeRecord do
     end
 
     it "returns true if method is in self" do
-      expect(subject.respond_to?(:to_s)).to be_truthy
+      expect(subject.respond_to?(:to_s)).to eq(true)
     end
 
     it "returns true if method is in hierarchy" do
-      expect(subject.respond_to?(:nil?)).to be_truthy
+      expect(subject.respond_to?(:nil?)).to eq(true)
     end
 
     it "returns true if method is a property" do
       Whois::Parser::PROPERTIES << :test_property
-      expect(subject.respond_to?(:test_property)).to be_truthy
+      expect(subject.respond_to?(:test_property)).to eq(true)
     end
 
     it "returns true if method is a property?" do
       Whois::Parser::PROPERTIES << :test_property
-      expect(subject.respond_to?(:test_property?)).to be_truthy
+      expect(subject.respond_to?(:test_property?)).to eq(true)
     end
 
     it "returns true if method is a method" do
       Whois::Parser::METHODS << :test_method
-      expect(subject.respond_to?(:test_method)).to be_truthy
+      expect(subject.respond_to?(:test_method)).to eq(true)
     end
 
     it "returns true if method is a method" do
       Whois::Parser::METHODS << :test_method
-      expect(subject.respond_to?(:test_method?)).to be_truthy
+      expect(subject.respond_to?(:test_method?)).to eq(true)
     end
   end
 


### PR DESCRIPTION
The fact that `expect(42).to be_truthy` and `expect(nil).to be_falsey` both pass make them very imprecise and error prone. One should basically never use them in specs, imo.

Builds on #28 and #29 (to avoid conflicts)