### PR TITLE
Fix scanning issue with .ca when keys have no value

### DIFF
--- a/lib/whois/scanners/whois.cira.ca.rb
+++ b/lib/whois/scanners/whois.cira.ca.rb
@@ -23,7 +23,7 @@ module Whois
       end
 
       tokenizer :scan_header do
-        if @input.scan(/^(.+?):\n/)
+        if @input.scan(/^(\S.*?):\n/)
           @tmp["group"] = @input[1]
         end
       end

--- a/spec/fixtures/responses/whois.cira.ca/ca/property_status_redemption.expected
+++ b/spec/fixtures/responses/whois.cira.ca/ca/property_status_redemption.expected
@@ -6,3 +6,6 @@
 
 #registered?
   %s == true
+
+#admin_contacts[0].email
+  %s == "mail@sanamato.com"

--- a/spec/whois/parsers/responses/whois.cira.ca/ca/property_status_redemption_spec.rb
+++ b/spec/whois/parsers/responses/whois.cira.ca/ca/property_status_redemption_spec.rb
@@ -36,4 +36,9 @@ describe Whois::Parsers::WhoisCiraCa, "property_status_redemption.expected" do
       expect(subject.registered?).to eq(true)
     end
   end
+  describe "#admin_contacts[0].email" do
+    it do
+      expect(subject.admin_contacts[0].email).to eq("mail@sanamato.com")
+    end
+  end
 end


### PR DESCRIPTION
This parser is incorrectly interpreting a key with no accompanying value as a header.  An example of this can currently be seen in one of the existing test fixtures (fixtures/responses/whois.cira.ca/ca/property_status_redemption.txt), where "Fax:" has no value and as a result the "Email:" value that follows it is no properly inserted into the associated contact.

The fix relies on the lack of indentation for a line to be considered a header.
