### PR TITLE
Fix expires_on check for verisign domains

### DIFF
--- a/lib/whois/parsers/base_verisign.rb
+++ b/lib/whois/parsers/base_verisign.rb
@@ -30,7 +30,7 @@ module Whois
       end
 
       property_supported :domain_id do
-        node("Domain ID")
+        node("Registry Domain ID")
       end
 
 
@@ -66,9 +66,9 @@ module Whois
 
 
       property_supported :registrar do
-        node("Sponsoring Registrar") do |value|
+        node("Registrar") do |value|
           Parser::Registrar.new(
-              id:           last_useful_item(node("Sponsoring Registrar IANA ID")),
+              id:           last_useful_item(node("Registrar IANA ID")),
               name:         last_useful_item(value),
               url:          referral_url
           )
@@ -84,11 +84,11 @@ module Whois
 
 
       def referral_whois
-        node("Whois Server")
+        node("Registrar WHOIS Server")
       end
 
       def referral_url
-        last_useful_item(node("Referral URL"))
+        last_useful_item(node("Registrar URL"))
       end
 
 

--- a/lib/whois/parsers/whois.verisign-grs.com.rb
+++ b/lib/whois/parsers/whois.verisign-grs.com.rb
@@ -21,7 +21,7 @@ module Whois
     class WhoisVerisignGrsCom < BaseVerisign
 
       property_supported :expires_on do
-        node("Expiration Date") { |value| parse_time(value) }
+        node("Registry Expiry Date") { |value| parse_time(value) }
       end
 
 

--- a/lib/whois/parsers/whois.verisign-grs.com.rb
+++ b/lib/whois/parsers/whois.verisign-grs.com.rb
@@ -28,7 +28,7 @@ module Whois
       property_supported :registrar do
         node("Registrar") do |value|
           Parser::Registrar.new(
-              id:           last_useful_item(node("Sponsoring Registrar IANA ID")),
+              id:           last_useful_item(node("Registrar IANA ID")),
               name:         last_useful_item(value),
               url:          referral_url
           )

--- a/spec/fixtures/responses/ccwhois.verisign-grs.com/cc/status_registered.txt
+++ b/spec/fixtures/responses/ccwhois.verisign-grs.com/cc/status_registered.txt
@@ -1,64 +1,58 @@
-
-Whois Server Version 2.0
-
-Domain names can now be registered with many different competing registrars. 
-Go to http://registrar.verisign-grs.com/whois/ for detailed information.
-
    Domain Name: GOOGLE.CC
-   Domain ID: 86420657
-   Whois Server: whois.markmonitor.com
-   Referral URL: http://www.markmonitor.com
-   Updated Date: 2013-05-06T05:17:44Z
-   Creation Date: 1999-06-07T00:00:00Z
-   Registry Expiry Date: 2014-06-07T00:00:00Z
-   Sponsoring Registrar: MARKMONITOR INC.
-   Sponsoring Registrar IANA ID: 292
-   Domain Status: clientDeleteProhibited
-   Domain Status: clientTransferProhibited
-   Domain Status: clientUpdateProhibited
-   Domain Status: serverDeleteProhibited
-   Domain Status: serverTransferProhibited
-   Domain Status: serverUpdateProhibited
+   Registry Domain ID: 86420657_DOMAIN_CC-VRSN
+   Registrar WHOIS Server: whois.markmonitor.com
+   Registrar URL: http://www.markmonitor.com
+   Updated Date: 2017-05-06T09:28:40Z
+   Creation Date: 1999-06-07T04:00:00Z
+   Registry Expiry Date: 2018-06-07T04:00:00Z
+   Registrar: MARKMONITOR INC.
+   Registrar IANA ID: 292
+   Registrar Abuse Contact Email: abusecomplaints@markmonitor.com
+   Registrar Abuse Contact Phone: +1.2083895740
+   Domain Status: clientDeleteProhibited https://icann.org/epp#clientDeleteProhibited
+   Domain Status: clientTransferProhibited https://icann.org/epp#clientTransferProhibited
+   Domain Status: clientUpdateProhibited https://icann.org/epp#clientUpdateProhibited
+   Domain Status: serverDeleteProhibited https://icann.org/epp#serverDeleteProhibited
+   Domain Status: serverTransferProhibited https://icann.org/epp#serverTransferProhibited
+   Domain Status: serverUpdateProhibited https://icann.org/epp#serverUpdateProhibited
    Name Server: NS1.GOOGLE.COM
    Name Server: NS2.GOOGLE.COM
    Name Server: NS3.GOOGLE.COM
    Name Server: NS4.GOOGLE.COM
-   DNSSEC: Unsigned delegation
+   DNSSEC: unsigned
+   URL of the ICANN Whois Inaccuracy Complaint Form: https://www.icann.org/wicf/
+>>> Last update of WHOIS database: 2017-08-01T00:30:52Z <<<
 
+For more information on Whois status codes, please visit https://icann.org/epp
 
->>> Last update of whois database: 2014-03-18T13:32:28Z <<<
-
-NOTICE: The expiration date displayed in this record is the date the 
-registrar's sponsorship of the domain name registration in the registry is 
-currently set to expire. This date does not necessarily reflect the 
-expiration date of the domain name registrant's agreement with the 
-sponsoring registrar.  Users may consult the sponsoring registrar's 
-Whois database to view the registrar's reported date of expiration 
+NOTICE: The expiration date displayed in this record is the date the
+registrar's sponsorship of the domain name registration in the registry is
+currently set to expire. This date does not necessarily reflect the
+expiration date of the domain name registrant's agreement with the
+sponsoring registrar.  Users may consult the sponsoring registrar's
+Whois database to view the registrar's reported date of expiration
 for this registration.
 
-TERMS OF USE: You are not authorized to access or query our Whois 
-database through the use of electronic processes that are high-volume and 
-automated except as reasonably necessary to register domain names or 
-modify existing registrations; the Data in VeriSign's ("VeriSign") Whois 
-database is provided by VeriSign for information purposes only, and to 
-assist persons in obtaining information about or related to a domain name 
-registration record. VeriSign does not guarantee its accuracy. 
-By submitting a Whois query, you agree to abide by the following terms of 
-use: You agree that you may use this Data only for lawful purposes and that 
-under no circumstances will you use this Data to: (1) allow, enable, or 
-otherwise support the transmission of mass unsolicited, commercial 
-advertising or solicitations via e-mail, telephone, or facsimile; or 
-(2) enable high volume, automated, electronic processes that apply to 
-VeriSign (or its computer systems). The compilation, repackaging, 
-dissemination or other use of this Data is expressly prohibited without 
-the prior written consent of VeriSign. You agree not to use electronic 
-processes that are automated and high-volume to access or query the 
-Whois database except as reasonably necessary to register domain names 
-or modify existing registrations. VeriSign reserves the right to restrict 
-your access to the Whois database in its sole discretion to ensure 
-operational stability.  VeriSign may restrict or terminate your access to the 
-Whois database for failure to abide by these terms of use. VeriSign 
-reserves the right to modify these terms at any time. 
-
-The Registry database contains ONLY .cc, .tv, and .jobs domains 
-and Registrars.
+TERMS OF USE: You are not authorized to access or query our Whois
+database through the use of electronic processes that are high-volume and
+automated except as reasonably necessary to register domain names or
+modify existing registrations; the Data in VeriSign's ("VeriSign") Whois
+database is provided by VeriSign for information purposes only, and to
+assist persons in obtaining information about or related to a domain name
+registration record. VeriSign does not guarantee its accuracy.
+By submitting a Whois query, you agree to abide by the following terms of
+use: You agree that you may use this Data only for lawful purposes and that
+under no circumstances will you use this Data to: (1) allow, enable, or
+otherwise support the transmission of mass unsolicited, commercial
+advertising or solicitations via e-mail, telephone, or facsimile; or
+(2) enable high volume, automated, electronic processes that apply to
+VeriSign (or its computer systems). The compilation, repackaging,
+dissemination or other use of this Data is expressly prohibited without
+the prior written consent of VeriSign. You agree not to use electronic
+processes that are automated and high-volume to access or query the
+Whois database except as reasonably necessary to register domain names
+or modify existing registrations. VeriSign reserves the right to restrict
+your access to the Whois database in its sole discretion to ensure
+operational stability.  VeriSign may restrict or terminate your access to the
+Whois database for failure to abide by these terms of use. VeriSign
+reserves the right to modify these terms at any time.

--- a/spec/fixtures/responses/tvwhois.verisign-grs.com/tv/status_registered.txt
+++ b/spec/fixtures/responses/tvwhois.verisign-grs.com/tv/status_registered.txt
@@ -1,59 +1,57 @@
-
-Whois Server Version 2.0
-
-Domain names can now be registered with many different competing registrars. 
-Go to http://registrar.verisign-grs.com/whois/ for detailed information.
-
    Domain Name: GOOGLE.TV
-   Domain ID: 87196881
-   Whois Server: whois.enom.com
-   Referral URL: http://www.enom.com
-   Updated Date: 2013-07-09T17:03:47Z
-   Creation Date: 2002-08-02T12:43:36Z
-   Registry Expiry Date: 2014-08-02T12:43:36Z
-   Sponsoring Registrar: ENOM, INC.
-   Sponsoring Registrar IANA ID: 48
-   Domain Status: clientDeleteProhibited
-   Domain Status: clientTransferProhibited
+   Registry Domain ID: 87196881_DOMAIN_TV-VRSN
+   Registrar WHOIS Server: whois.markmonitor.com
+   Registrar URL: http://www.markmonitor.com
+   Updated Date: 2017-07-01T09:25:47Z
+   Creation Date: 2002-08-02T16:43:36Z
+   Registry Expiry Date: 2018-08-02T16:43:36Z
+   Registrar: MARKMONITOR INC.
+   Registrar IANA ID: 292
+   Registrar Abuse Contact Email: abusecomplaints@markmonitor.com
+   Registrar Abuse Contact Phone: +1.2083895740
+   Domain Status: clientDeleteProhibited https://icann.org/epp#clientDeleteProhibited
+   Domain Status: clientTransferProhibited https://icann.org/epp#clientTransferProhibited
+   Domain Status: clientUpdateProhibited https://icann.org/epp#clientUpdateProhibited
+   Domain Status: serverDeleteProhibited https://icann.org/epp#serverDeleteProhibited
+   Domain Status: serverTransferProhibited https://icann.org/epp#serverTransferProhibited
+   Domain Status: serverUpdateProhibited https://icann.org/epp#serverUpdateProhibited
    Name Server: NS1.GOOGLE.COM
    Name Server: NS2.GOOGLE.COM
    Name Server: NS3.GOOGLE.COM
-   DNSSEC: Unsigned delegation
+   DNSSEC: unsigned
+   URL of the ICANN Whois Inaccuracy Complaint Form: https://www.icann.org/wicf/
+>>> Last update of WHOIS database: 2017-08-01T00:34:52Z <<<
 
+For more information on Whois status codes, please visit https://icann.org/epp
 
->>> Last update of whois database: 2014-03-18T13:18:41Z <<<
-
-NOTICE: The expiration date displayed in this record is the date the 
-registrar's sponsorship of the domain name registration in the registry is 
-currently set to expire. This date does not necessarily reflect the 
-expiration date of the domain name registrant's agreement with the 
-sponsoring registrar.  Users may consult the sponsoring registrar's 
-Whois database to view the registrar's reported date of expiration 
+NOTICE: The expiration date displayed in this record is the date the
+registrar's sponsorship of the domain name registration in the registry is
+currently set to expire. This date does not necessarily reflect the
+expiration date of the domain name registrant's agreement with the
+sponsoring registrar.  Users may consult the sponsoring registrar's
+Whois database to view the registrar's reported date of expiration
 for this registration.
 
-TERMS OF USE: You are not authorized to access or query our Whois 
-database through the use of electronic processes that are high-volume and 
-automated except as reasonably necessary to register domain names or 
-modify existing registrations; the Data in VeriSign's ("VeriSign") Whois 
-database is provided by VeriSign for information purposes only, and to 
-assist persons in obtaining information about or related to a domain name 
-registration record. VeriSign does not guarantee its accuracy. 
-By submitting a Whois query, you agree to abide by the following terms of 
-use: You agree that you may use this Data only for lawful purposes and that 
-under no circumstances will you use this Data to: (1) allow, enable, or 
-otherwise support the transmission of mass unsolicited, commercial 
-advertising or solicitations via e-mail, telephone, or facsimile; or 
-(2) enable high volume, automated, electronic processes that apply to 
-VeriSign (or its computer systems). The compilation, repackaging, 
-dissemination or other use of this Data is expressly prohibited without 
-the prior written consent of VeriSign. You agree not to use electronic 
-processes that are automated and high-volume to access or query the 
-Whois database except as reasonably necessary to register domain names 
-or modify existing registrations. VeriSign reserves the right to restrict 
-your access to the Whois database in its sole discretion to ensure 
-operational stability.  VeriSign may restrict or terminate your access to the 
-Whois database for failure to abide by these terms of use. VeriSign 
-reserves the right to modify these terms at any time. 
-
-The Registry database contains ONLY .cc, .tv, and .jobs domains 
-and Registrars.
+TERMS OF USE: You are not authorized to access or query our Whois
+database through the use of electronic processes that are high-volume and
+automated except as reasonably necessary to register domain names or
+modify existing registrations; the Data in VeriSign's ("VeriSign") Whois
+database is provided by VeriSign for information purposes only, and to
+assist persons in obtaining information about or related to a domain name
+registration record. VeriSign does not guarantee its accuracy.
+By submitting a Whois query, you agree to abide by the following terms of
+use: You agree that you may use this Data only for lawful purposes and that
+under no circumstances will you use this Data to: (1) allow, enable, or
+otherwise support the transmission of mass unsolicited, commercial
+advertising or solicitations via e-mail, telephone, or facsimile; or
+(2) enable high volume, automated, electronic processes that apply to
+VeriSign (or its computer systems). The compilation, repackaging,
+dissemination or other use of this Data is expressly prohibited without
+the prior written consent of VeriSign. You agree not to use electronic
+processes that are automated and high-volume to access or query the
+Whois database except as reasonably necessary to register domain names
+or modify existing registrations. VeriSign reserves the right to restrict
+your access to the Whois database in its sole discretion to ensure
+operational stability.  VeriSign may restrict or terminate your access to the
+Whois database for failure to abide by these terms of use. VeriSign
+reserves the right to modify these terms at any time.

--- a/spec/fixtures/responses/whois.markmonitor.com/cc/status_registered.txt
+++ b/spec/fixtures/responses/whois.markmonitor.com/cc/status_registered.txt
@@ -1,10 +1,10 @@
-Domain Name: google.com
-Registry Domain ID: 2138514_DOMAIN_COM-VRSN
+Domain Name: google.cc
+Registry Domain ID: 86420657_DOMAIN_CC-VRSN
 Registrar WHOIS Server: whois.markmonitor.com
 Registrar URL: http://www.markmonitor.com
-Updated Date: 2015-06-12T10:38:52-0700
-Creation Date: 1997-09-15T00:00:00-0700
-Registrar Registration Expiration Date: 2020-09-13T21:00:00-0700
+Updated Date: 2017-05-06T02:28:41-0700
+Creation Date: 1999-06-07T00:00:00-0700
+Registrar Registration Expiration Date: 2018-06-06T00:00:00-0700
 Registrar: MarkMonitor, Inc.
 Registrar IANA ID: 292
 Registrar Abuse Contact Email: abusecomplaints@markmonitor.com
@@ -16,14 +16,14 @@ Domain Status: serverUpdateProhibited (https://www.icann.org/epp#serverUpdatePro
 Domain Status: serverTransferProhibited (https://www.icann.org/epp#serverTransferProhibited)
 Domain Status: serverDeleteProhibited (https://www.icann.org/epp#serverDeleteProhibited)
 Registry Registrant ID: 
-Registrant Name: Dns Admin
+Registrant Name: DNS Admin
 Registrant Organization: Google Inc.
-Registrant Street: Please contact contact-admin@google.com, 1600 Amphitheatre Parkway
+Registrant Street: 1600 Amphitheatre Parkway
 Registrant City: Mountain View
 Registrant State/Province: CA
 Registrant Postal Code: 94043
 Registrant Country: US
-Registrant Phone: +1.6502530000
+Registrant Phone: +1.6506234000
 Registrant Phone Ext: 
 Registrant Fax: +1.6506188571
 Registrant Fax Ext: 
@@ -44,23 +44,23 @@ Admin Email: dns-admin@google.com
 Registry Tech ID: 
 Tech Name: DNS Admin
 Tech Organization: Google Inc.
-Tech Street: 2400 E. Bayshore Pkwy
+Tech Street: 1600 Amphitheatre Parkway
 Tech City: Mountain View
 Tech State/Province: CA
 Tech Postal Code: 94043
 Tech Country: US
-Tech Phone: +1.6503300100
+Tech Phone: +1.6506234000
 Tech Phone Ext: 
-Tech Fax: +1.6506181499
+Tech Fax: +1.6506188571
 Tech Fax Ext: 
 Tech Email: dns-admin@google.com
-Name Server: ns1.google.com
 Name Server: ns3.google.com
-Name Server: ns2.google.com
 Name Server: ns4.google.com
+Name Server: ns2.google.com
+Name Server: ns1.google.com
 DNSSEC: unsigned
 URL of the ICANN WHOIS Data Problem Reporting System: http://wdprs.internic.net/
->>> Last update of WHOIS database: 2017-07-31T16:57:35-0700 <<<
+>>> Last update of WHOIS database: 2017-07-31T17:31:01-0700 <<<
 
 The Data in MarkMonitor.com's WHOIS database is provided by MarkMonitor.com for
 information purposes, and to assist persons in obtaining information about or
@@ -88,4 +88,4 @@ In Europe, at +44.02032062220
 
 For more information on Whois status codes, please visit
  https://www.icann.org/resources/pages/epp-status-codes-2014-06-16-en
---
+

--- a/spec/fixtures/responses/whois.markmonitor.com/jobs/status_registered.txt
+++ b/spec/fixtures/responses/whois.markmonitor.com/jobs/status_registered.txt
@@ -1,10 +1,10 @@
-Domain Name: google.com
-Registry Domain ID: 2138514_DOMAIN_COM-VRSN
+Domain Name: google.jobs
+Registry Domain ID: 86932313_DOMAIN_JOBS-VRSN
 Registrar WHOIS Server: whois.markmonitor.com
 Registrar URL: http://www.markmonitor.com
-Updated Date: 2015-06-12T10:38:52-0700
-Creation Date: 1997-09-15T00:00:00-0700
-Registrar Registration Expiration Date: 2020-09-13T21:00:00-0700
+Updated Date: 2017-07-27T13:59:01-0700
+Creation Date: 2005-09-15T00:00:00-0700
+Registrar Registration Expiration Date: 2017-09-14T21:00:00-0700
 Registrar: MarkMonitor, Inc.
 Registrar IANA ID: 292
 Registrar Abuse Contact Email: abusecomplaints@markmonitor.com
@@ -12,13 +12,10 @@ Registrar Abuse Contact Phone: +1.2083895740
 Domain Status: clientUpdateProhibited (https://www.icann.org/epp#clientUpdateProhibited)
 Domain Status: clientTransferProhibited (https://www.icann.org/epp#clientTransferProhibited)
 Domain Status: clientDeleteProhibited (https://www.icann.org/epp#clientDeleteProhibited)
-Domain Status: serverUpdateProhibited (https://www.icann.org/epp#serverUpdateProhibited)
-Domain Status: serverTransferProhibited (https://www.icann.org/epp#serverTransferProhibited)
-Domain Status: serverDeleteProhibited (https://www.icann.org/epp#serverDeleteProhibited)
-Registry Registrant ID: 
-Registrant Name: Dns Admin
+Registry Registrant ID: MMR-168840
+Registrant Name: Domain Administrator
 Registrant Organization: Google Inc.
-Registrant Street: Please contact contact-admin@google.com, 1600 Amphitheatre Parkway
+Registrant Street: 1600 Amphitheatre Parkway, 
 Registrant City: Mountain View
 Registrant State/Province: CA
 Registrant Postal Code: 94043
@@ -28,39 +25,37 @@ Registrant Phone Ext:
 Registrant Fax: +1.6506188571
 Registrant Fax Ext: 
 Registrant Email: dns-admin@google.com
-Registry Admin ID: 
-Admin Name: DNS Admin
+Registry Admin ID: MMR-168840
+Admin Name: Domain Administrator
 Admin Organization: Google Inc.
-Admin Street: 1600 Amphitheatre Parkway
+Admin Street: 1600 Amphitheatre Parkway, 
 Admin City: Mountain View
 Admin State/Province: CA
 Admin Postal Code: 94043
 Admin Country: US
-Admin Phone: +1.6506234000
+Admin Phone: +1.6502530000
 Admin Phone Ext: 
 Admin Fax: +1.6506188571
 Admin Fax Ext: 
 Admin Email: dns-admin@google.com
-Registry Tech ID: 
-Tech Name: DNS Admin
+Registry Tech ID: MMR-168840
+Tech Name: Domain Administrator
 Tech Organization: Google Inc.
-Tech Street: 2400 E. Bayshore Pkwy
+Tech Street: 1600 Amphitheatre Parkway, 
 Tech City: Mountain View
 Tech State/Province: CA
 Tech Postal Code: 94043
 Tech Country: US
-Tech Phone: +1.6503300100
+Tech Phone: +1.6502530000
 Tech Phone Ext: 
-Tech Fax: +1.6506181499
+Tech Fax: +1.6506188571
 Tech Fax Ext: 
 Tech Email: dns-admin@google.com
 Name Server: ns1.google.com
-Name Server: ns3.google.com
 Name Server: ns2.google.com
-Name Server: ns4.google.com
 DNSSEC: unsigned
 URL of the ICANN WHOIS Data Problem Reporting System: http://wdprs.internic.net/
->>> Last update of WHOIS database: 2017-07-31T16:57:35-0700 <<<
+>>> Last update of WHOIS database: 2017-07-31T17:35:22-0700 <<<
 
 The Data in MarkMonitor.com's WHOIS database is provided by MarkMonitor.com for
 information purposes, and to assist persons in obtaining information about or
@@ -88,4 +83,4 @@ In Europe, at +44.02032062220
 
 For more information on Whois status codes, please visit
  https://www.icann.org/resources/pages/epp-status-codes-2014-06-16-en
---
+

--- a/spec/fixtures/responses/whois.markmonitor.com/net/status_registered.txt
+++ b/spec/fixtures/responses/whois.markmonitor.com/net/status_registered.txt
@@ -1,17 +1,20 @@
 Domain Name: google.net
-Registry Domain ID: 
+Registry Domain ID: 4802712_DOMAIN_NET-VRSN
 Registrar WHOIS Server: whois.markmonitor.com
 Registrar URL: http://www.markmonitor.com
-Updated Date: 2014-02-11T02:23:44-0800
-Creation Date: 2002-10-02T00:00:00-0700
-Registrar Registration Expiration Date: 2015-03-14T21:00:00-0700
+Updated Date: 2017-02-11T02:56:38-0800
+Creation Date: 1999-03-15T00:00:00-0800
+Registrar Registration Expiration Date: 2018-03-14T00:00:00-0700
 Registrar: MarkMonitor, Inc.
 Registrar IANA ID: 292
-Registrar Abuse Contact Email: compliance@markmonitor.com
+Registrar Abuse Contact Email: abusecomplaints@markmonitor.com
 Registrar Abuse Contact Phone: +1.2083895740
-Domain Status: clientUpdateProhibited
-Domain Status: clientTransferProhibited
-Domain Status: clientDeleteProhibited
+Domain Status: clientUpdateProhibited (https://www.icann.org/epp#clientUpdateProhibited)
+Domain Status: clientTransferProhibited (https://www.icann.org/epp#clientTransferProhibited)
+Domain Status: clientDeleteProhibited (https://www.icann.org/epp#clientDeleteProhibited)
+Domain Status: serverUpdateProhibited (https://www.icann.org/epp#serverUpdateProhibited)
+Domain Status: serverTransferProhibited (https://www.icann.org/epp#serverTransferProhibited)
+Domain Status: serverDeleteProhibited (https://www.icann.org/epp#serverDeleteProhibited)
 Registry Registrant ID: 
 Registrant Name: DNS Admin
 Registrant Organization: Google Inc.
@@ -52,11 +55,12 @@ Tech Fax: +1.6506188571
 Tech Fax Ext: 
 Tech Email: dns-admin@google.com
 Name Server: ns1.google.com
+Name Server: ns3.google.com
 Name Server: ns2.google.com
 Name Server: ns4.google.com
-Name Server: ns3.google.com
+DNSSEC: unsigned
 URL of the ICANN WHOIS Data Problem Reporting System: http://wdprs.internic.net/
->>> Last update of WHOIS database: 2014-03-18T06:37:44-0700 <<<
+>>> Last update of WHOIS database: 2017-07-31T18:39:55-0700 <<<
 
 The Data in MarkMonitor.com's WHOIS database is provided by MarkMonitor.com for
 information purposes, and to assist persons in obtaining information about or
@@ -81,4 +85,7 @@ Professional and Managed Services
 Visit MarkMonitor at http://www.markmonitor.com
 Contact us at +1.8007459229
 In Europe, at +44.02032062220
+
+For more information on Whois status codes, please visit
+ https://www.icann.org/resources/pages/epp-status-codes-2014-06-16-en
 

--- a/spec/fixtures/responses/whois.markmonitor.com/tv/status_registered.txt
+++ b/spec/fixtures/responses/whois.markmonitor.com/tv/status_registered.txt
@@ -1,10 +1,10 @@
-Domain Name: google.com
-Registry Domain ID: 2138514_DOMAIN_COM-VRSN
+Domain Name: google.tv
+Registry Domain ID: 
 Registrar WHOIS Server: whois.markmonitor.com
 Registrar URL: http://www.markmonitor.com
-Updated Date: 2015-06-12T10:38:52-0700
-Creation Date: 1997-09-15T00:00:00-0700
-Registrar Registration Expiration Date: 2020-09-13T21:00:00-0700
+Updated Date: 2017-07-01T02:25:47-0700
+Creation Date: 2004-08-02T00:00:00-0700
+Registrar Registration Expiration Date: 2018-08-02T00:00:00-0700
 Registrar: MarkMonitor, Inc.
 Registrar IANA ID: 292
 Registrar Abuse Contact Email: abusecomplaints@markmonitor.com
@@ -16,51 +16,50 @@ Domain Status: serverUpdateProhibited (https://www.icann.org/epp#serverUpdatePro
 Domain Status: serverTransferProhibited (https://www.icann.org/epp#serverTransferProhibited)
 Domain Status: serverDeleteProhibited (https://www.icann.org/epp#serverDeleteProhibited)
 Registry Registrant ID: 
-Registrant Name: Dns Admin
+Registrant Name: DNS Admin
 Registrant Organization: Google Inc.
-Registrant Street: Please contact contact-admin@google.com, 1600 Amphitheatre Parkway
+Registrant Street: 1600 Amphitheatre Parkway, 
 Registrant City: Mountain View
 Registrant State/Province: CA
 Registrant Postal Code: 94043
 Registrant Country: US
 Registrant Phone: +1.6502530000
 Registrant Phone Ext: 
-Registrant Fax: +1.6506188571
+Registrant Fax: +1.6502530001
 Registrant Fax Ext: 
 Registrant Email: dns-admin@google.com
 Registry Admin ID: 
 Admin Name: DNS Admin
 Admin Organization: Google Inc.
-Admin Street: 1600 Amphitheatre Parkway
+Admin Street: 1600 Amphitheatre Parkway, 
 Admin City: Mountain View
 Admin State/Province: CA
 Admin Postal Code: 94043
 Admin Country: US
-Admin Phone: +1.6506234000
+Admin Phone: +1.6502530000
 Admin Phone Ext: 
-Admin Fax: +1.6506188571
+Admin Fax: +1.6502530001
 Admin Fax Ext: 
 Admin Email: dns-admin@google.com
 Registry Tech ID: 
 Tech Name: DNS Admin
 Tech Organization: Google Inc.
-Tech Street: 2400 E. Bayshore Pkwy
+Tech Street: 1600 Amphitheatre Parkway, 
 Tech City: Mountain View
 Tech State/Province: CA
 Tech Postal Code: 94043
 Tech Country: US
-Tech Phone: +1.6503300100
+Tech Phone: +1.6502530000
 Tech Phone Ext: 
-Tech Fax: +1.6506181499
+Tech Fax: +1.6502530001
 Tech Fax Ext: 
 Tech Email: dns-admin@google.com
+Name Server: ns2.google.com
 Name Server: ns1.google.com
 Name Server: ns3.google.com
-Name Server: ns2.google.com
-Name Server: ns4.google.com
 DNSSEC: unsigned
 URL of the ICANN WHOIS Data Problem Reporting System: http://wdprs.internic.net/
->>> Last update of WHOIS database: 2017-07-31T16:57:35-0700 <<<
+>>> Last update of WHOIS database: 2017-07-31T17:35:02-0700 <<<
 
 The Data in MarkMonitor.com's WHOIS database is provided by MarkMonitor.com for
 information purposes, and to assist persons in obtaining information about or
@@ -88,4 +87,4 @@ In Europe, at +44.02032062220
 
 For more information on Whois status codes, please visit
  https://www.icann.org/resources/pages/epp-status-codes-2014-06-16-en
---
+

--- a/spec/fixtures/responses/whois.nic.jobs/jobs/status_registered.txt
+++ b/spec/fixtures/responses/whois.nic.jobs/jobs/status_registered.txt
@@ -1,59 +1,53 @@
-
-Whois Server Version 2.0
-
-Domain names can now be registered with many different competing registrars. 
-Go to http://registrar.verisign-grs.com/whois/ for detailed information.
-
    Domain Name: GOOGLE.JOBS
-   Domain ID: 86932313
-   Whois Server: whois.markmonitor.com
-   Referral URL: http://www.markmonitor.com
-   Updated Date: 2013-08-14T05:20:33Z
-   Creation Date: 2005-09-15T00:00:00Z
-   Registry Expiry Date: 2014-09-15T00:00:00Z
-   Sponsoring Registrar: MARKMONITOR INC.
-   Sponsoring Registrar IANA ID: 292
-   Domain Status: clientDeleteProhibited
-   Domain Status: clientTransferProhibited
-   Domain Status: clientUpdateProhibited
+   Registry Domain ID: 86932313_DOMAIN_JOBS-VRSN
+   Registrar WHOIS Server: whois.markmonitor.com
+   Registrar URL: http://www.markmonitor.com
+   Updated Date: 2017-07-27T20:59:01Z
+   Creation Date: 2005-09-15T04:00:00Z
+   Registry Expiry Date: 2017-09-15T04:00:00Z
+   Registrar: MARKMONITOR INC.
+   Registrar IANA ID: 292
+   Registrar Abuse Contact Email: abusecomplaints@markmonitor.com
+   Registrar Abuse Contact Phone: +1.2083895740
+   Domain Status: clientDeleteProhibited https://icann.org/epp#clientDeleteProhibited
+   Domain Status: clientTransferProhibited https://icann.org/epp#clientTransferProhibited
+   Domain Status: clientUpdateProhibited https://icann.org/epp#clientUpdateProhibited
    Name Server: NS1.GOOGLE.COM
    Name Server: NS2.GOOGLE.COM
-   DNSSEC: Unsigned delegation
+   DNSSEC: unsigned
+   URL of the ICANN Whois Inaccuracy Complaint Form: https://www.icann.org/wicf/
+>>> Last update of WHOIS database: 2017-08-01T00:35:07Z <<<
 
+For more information on Whois status codes, please visit https://icann.org/epp
 
->>> Last update of whois database: 2014-03-18T13:32:58Z <<<
-
-NOTICE: The expiration date displayed in this record is the date the 
-registrar's sponsorship of the domain name registration in the registry is 
-currently set to expire. This date does not necessarily reflect the 
-expiration date of the domain name registrant's agreement with the 
-sponsoring registrar.  Users may consult the sponsoring registrar's 
-Whois database to view the registrar's reported date of expiration 
+NOTICE: The expiration date displayed in this record is the date the
+registrar's sponsorship of the domain name registration in the registry is
+currently set to expire. This date does not necessarily reflect the
+expiration date of the domain name registrant's agreement with the
+sponsoring registrar.  Users may consult the sponsoring registrar's
+Whois database to view the registrar's reported date of expiration
 for this registration.
 
-TERMS OF USE: You are not authorized to access or query our Whois 
-database through the use of electronic processes that are high-volume and 
-automated except as reasonably necessary to register domain names or 
-modify existing registrations; the Data in VeriSign's ("VeriSign") Whois 
-database is provided by VeriSign for information purposes only, and to 
-assist persons in obtaining information about or related to a domain name 
-registration record. VeriSign does not guarantee its accuracy. 
-By submitting a Whois query, you agree to abide by the following terms of 
-use: You agree that you may use this Data only for lawful purposes and that 
-under no circumstances will you use this Data to: (1) allow, enable, or 
-otherwise support the transmission of mass unsolicited, commercial 
-advertising or solicitations via e-mail, telephone, or facsimile; or 
-(2) enable high volume, automated, electronic processes that apply to 
-VeriSign (or its computer systems). The compilation, repackaging, 
-dissemination or other use of this Data is expressly prohibited without 
-the prior written consent of VeriSign. You agree not to use electronic 
-processes that are automated and high-volume to access or query the 
-Whois database except as reasonably necessary to register domain names 
-or modify existing registrations. VeriSign reserves the right to restrict 
-your access to the Whois database in its sole discretion to ensure 
-operational stability.  VeriSign may restrict or terminate your access to the 
-Whois database for failure to abide by these terms of use. VeriSign 
-reserves the right to modify these terms at any time. 
-
-The Registry database contains ONLY .cc, .tv, and .jobs domains 
-and Registrars.
+TERMS OF USE: You are not authorized to access or query our Whois
+database through the use of electronic processes that are high-volume and
+automated except as reasonably necessary to register domain names or
+modify existing registrations; the Data in VeriSign's ("VeriSign") Whois
+database is provided by VeriSign for information purposes only, and to
+assist persons in obtaining information about or related to a domain name
+registration record. VeriSign does not guarantee its accuracy.
+By submitting a Whois query, you agree to abide by the following terms of
+use: You agree that you may use this Data only for lawful purposes and that
+under no circumstances will you use this Data to: (1) allow, enable, or
+otherwise support the transmission of mass unsolicited, commercial
+advertising or solicitations via e-mail, telephone, or facsimile; or
+(2) enable high volume, automated, electronic processes that apply to
+VeriSign (or its computer systems). The compilation, repackaging,
+dissemination or other use of this Data is expressly prohibited without
+the prior written consent of VeriSign. You agree not to use electronic
+processes that are automated and high-volume to access or query the
+Whois database except as reasonably necessary to register domain names
+or modify existing registrations. VeriSign reserves the right to restrict
+your access to the Whois database in its sole discretion to ensure
+operational stability.  VeriSign may restrict or terminate your access to the
+Whois database for failure to abide by these terms of use. VeriSign
+reserves the right to modify these terms at any time.

--- a/spec/fixtures/responses/whois.verisign-grs.com/com/property_registrar_with_multiple_entries.txt
+++ b/spec/fixtures/responses/whois.verisign-grs.com/com/property_registrar_with_multiple_entries.txt
@@ -9,246 +9,246 @@ for detailed information.
    IP Address: 50.23.75.44
    Registrar: PDR LTD. D/B/A PUBLICDOMAINREGISTRY.COM
    Whois Server: whois.PublicDomainRegistry.com
-   Referral URL: http://www.PublicDomainRegistry.com
+   Registrar URL: http://www.PublicDomainRegistry.com
 
    Server Name: GOOGLE.COM.ZZZZZZZZZZZZZ.GET.ONE.MILLION.DOLLARS.AT.WWW.UNIMUNDI.COM
    IP Address: 209.126.190.70
    Registrar: PDR LTD. D/B/A PUBLICDOMAINREGISTRY.COM
    Whois Server: whois.PublicDomainRegistry.com
-   Referral URL: http://www.PublicDomainRegistry.com
+   Registrar URL: http://www.PublicDomainRegistry.com
 
    Server Name: GOOGLE.COM.ZZZZZ.GET.LAID.AT.WWW.SWINGINGCOMMUNITY.COM
    IP Address: 69.41.185.195
    Registrar: TUCOWS DOMAINS INC.
    Whois Server: whois.tucows.com
-   Referral URL: http://domainhelp.opensrs.net
+   Registrar URL: http://domainhelp.opensrs.net
 
    Server Name: GOOGLE.COM.ZOMBIED.AND.HACKED.BY.WWW.WEB-HACK.COM
    IP Address: 217.107.217.167
    Registrar: DOMAINCONTEXT, INC.
    Whois Server: whois.domaincontext.com
-   Referral URL: http://www.domaincontext.com
+   Registrar URL: http://www.domaincontext.com
 
    Server Name: GOOGLE.COM.ZNAET.PRODOMEN.COM
    IP Address: 62.149.23.126
    Registrar: PDR LTD. D/B/A PUBLICDOMAINREGISTRY.COM
    Whois Server: whois.PublicDomainRegistry.com
-   Referral URL: http://www.PublicDomainRegistry.com
+   Registrar URL: http://www.PublicDomainRegistry.com
 
    Server Name: GOOGLE.COM.YUCEKIRBAC.COM
    IP Address: 88.246.115.134
    Registrar: PDR LTD. D/B/A PUBLICDOMAINREGISTRY.COM
    Whois Server: whois.PublicDomainRegistry.com
-   Referral URL: http://www.PublicDomainRegistry.com
+   Registrar URL: http://www.PublicDomainRegistry.com
 
    Server Name: GOOGLE.COM.YUCEHOCA.COM
    IP Address: 88.246.115.134
    Registrar: PDR LTD. D/B/A PUBLICDOMAINREGISTRY.COM
    Whois Server: whois.PublicDomainRegistry.com
-   Referral URL: http://www.PublicDomainRegistry.com
+   Registrar URL: http://www.PublicDomainRegistry.com
 
    Server Name: GOOGLE.COM.WORDT.DOOR.VEEL.WHTERS.GEBRUIKT.SERVERTJE.NET
    IP Address: 62.41.27.144
    Registrar: KEY-SYSTEMS GMBH
    Whois Server: whois.rrpproxy.net
-   Referral URL: http://www.key-systems.net
+   Registrar URL: http://www.key-systems.net
 
    Server Name: GOOGLE.COM.VN
    Registrar: ONLINENIC, INC.
    Whois Server: whois.onlinenic.com
-   Referral URL: http://www.OnlineNIC.com
+   Registrar URL: http://www.OnlineNIC.com
 
    Server Name: GOOGLE.COM.VABDAYOFF.COM
    IP Address: 8.8.8.8
    Registrar: DOMAIN.COM, LLC
    Whois Server: whois.domain.com
-   Referral URL: http://www.domain.com
+   Registrar URL: http://www.domain.com
 
    Server Name: GOOGLE.COM.UY
    Registrar: PDR LTD. D/B/A PUBLICDOMAINREGISTRY.COM
    Whois Server: whois.PublicDomainRegistry.com
-   Referral URL: http://www.PublicDomainRegistry.com
+   Registrar URL: http://www.PublicDomainRegistry.com
 
    Server Name: GOOGLE.COM.UA
    Registrar: PDR LTD. D/B/A PUBLICDOMAINREGISTRY.COM
    Whois Server: whois.PublicDomainRegistry.com
-   Referral URL: http://www.PublicDomainRegistry.com
+   Registrar URL: http://www.PublicDomainRegistry.com
 
    Server Name: GOOGLE.COM.TW
    Registrar: WEB COMMERCE COMMUNICATIONS LIMITED DBA WEBNIC.CC
    Whois Server: whois.webnic.cc
-   Referral URL: http://www.webnic.cc
+   Registrar URL: http://www.webnic.cc
 
    Server Name: GOOGLE.COM.TR
    Registrar: PDR LTD. D/B/A PUBLICDOMAINREGISTRY.COM
    Whois Server: whois.PublicDomainRegistry.com
-   Referral URL: http://www.PublicDomainRegistry.com
+   Registrar URL: http://www.PublicDomainRegistry.com
 
    Server Name: GOOGLE.COM.SUCKS.FIND.CRACKZ.WITH.SEARCH.GULLI.COM
    IP Address: 80.190.192.24
    Registrar: CORE INTERNET COUNCIL OF REGISTRARS
    Whois Server: whois.corenic.net
-   Referral URL: http://www.corenic.net
+   Registrar URL: http://www.corenic.net
 
    Server Name: GOOGLE.COM.SPROSIUYANDEKSA.RU
    Registrar: MELBOURNE IT, LTD. D/B/A INTERNET NAMES WORLDWIDE
    Whois Server: whois.melbourneit.com
-   Referral URL: http://www.melbourneit.com
+   Registrar URL: http://www.melbourneit.com
 
    Server Name: GOOGLE.COM.SPAMMING.IS.UNETHICAL.PLEASE.STOP.THEM.HUAXUEERBAN.COM
    IP Address: 211.64.175.66
    IP Address: 211.64.175.67
    Registrar: GODADDY.COM, LLC
    Whois Server: whois.godaddy.com
-   Referral URL: http://registrar.godaddy.com
+   Registrar URL: http://registrar.godaddy.com
 
    Server Name: GOOGLE.COM.SOUTHBEACHNEEDLEARTISTRY.COM
    IP Address: 74.125.229.52
    Registrar: GODADDY.COM, LLC
    Whois Server: whois.godaddy.com
-   Referral URL: http://registrar.godaddy.com
+   Registrar URL: http://registrar.godaddy.com
 
    Server Name: GOOGLE.COM.SHQIPERIA.COM
    IP Address: 70.84.145.107
    Registrar: ENOM, INC.
    Whois Server: whois.enom.com
-   Referral URL: http://www.enom.com
+   Registrar URL: http://www.enom.com
 
    Server Name: GOOGLE.COM.SA
    Registrar: OMNIS NETWORK, LLC
    Whois Server: whois.omnis.com
-   Referral URL: http://domains.omnis.com
+   Registrar URL: http://domains.omnis.com
 
    Server Name: GOOGLE.COM.PK
    Registrar: BIGROCK SOLUTIONS LIMITED
    Whois Server: Whois.bigrock.com
-   Referral URL: http://www.bigrock.com
+   Registrar URL: http://www.bigrock.com
 
    Server Name: GOOGLE.COM.PE
    Registrar: PDR LTD. D/B/A PUBLICDOMAINREGISTRY.COM
    Whois Server: whois.PublicDomainRegistry.com
-   Referral URL: http://www.PublicDomainRegistry.com
+   Registrar URL: http://www.PublicDomainRegistry.com
 
    Server Name: GOOGLE.COM.NS2.CHALESHGAR.COM
    IP Address: 8.8.8.8
    Registrar: REALTIME REGISTER BV
    Whois Server: whois.yoursrs.com
-   Referral URL: http://www.realtimeregister.com
+   Registrar URL: http://www.realtimeregister.com
 
    Server Name: GOOGLE.COM.NS1.CHALESHGAR.COM
    IP Address: 8.8.8.8
    Registrar: REALTIME REGISTER BV
    Whois Server: whois.yoursrs.com
-   Referral URL: http://www.realtimeregister.com
+   Registrar URL: http://www.realtimeregister.com
 
    Server Name: GOOGLE.COM.MY
    Registrar: WILD WEST DOMAINS, LLC
    Whois Server: whois.wildwestdomains.com
-   Referral URL: http://www.wildwestdomains.com
+   Registrar URL: http://www.wildwestdomains.com
 
    Server Name: GOOGLE.COM.MX
    Registrar: PDR LTD. D/B/A PUBLICDOMAINREGISTRY.COM
    Whois Server: whois.PublicDomainRegistry.com
-   Referral URL: http://www.PublicDomainRegistry.com
+   Registrar URL: http://www.PublicDomainRegistry.com
 
    Server Name: GOOGLE.COM.LOLOLOLOLOL.SHTHEAD.COM
    IP Address: 123.123.123.123
    Registrar: CRAZY DOMAINS FZ-LLC
    Whois Server: whois.syra.com.au
-   Referral URL: http://www.crazydomains.com 
+   Registrar URL: http://www.crazydomains.com
 
    Server Name: GOOGLE.COM.LASERPIPE.COM
    IP Address: 209.85.227.106
    Registrar: REALTIME REGISTER BV
    Whois Server: whois.yoursrs.com
-   Referral URL: http://www.realtimeregister.com
+   Registrar URL: http://www.realtimeregister.com
 
    Server Name: GOOGLE.COM.IS.NOT.HOSTED.BY.ACTIVEDOMAINDNS.NET
    IP Address: 217.148.161.5
    Registrar: ENOM, INC.
    Whois Server: whois.enom.com
-   Referral URL: http://www.enom.com
+   Registrar URL: http://www.enom.com
 
    Server Name: GOOGLE.COM.IS.HOSTED.ON.PROFITHOSTING.NET
    IP Address: 66.49.213.213
    Registrar: NAME.COM, INC.
    Whois Server: whois.name.com
-   Referral URL: http://www.name.com
+   Registrar URL: http://www.name.com
 
    Server Name: GOOGLE.COM.IS.APPROVED.BY.NUMEA.COM
    IP Address: 213.228.0.43
    Registrar: GANDI SAS
    Whois Server: whois.gandi.net
-   Referral URL: http://www.gandi.net
+   Registrar URL: http://www.gandi.net
 
    Server Name: GOOGLE.COM.HK
    Registrar: CLOUD GROUP LIMITED
    Whois Server: whois.hostingservicesinc.net
-   Referral URL: http://www.resell.biz
+   Registrar URL: http://www.resell.biz
 
    Server Name: GOOGLE.COM.HICHINA.COM
    IP Address: 218.103.1.1
    Registrar: HICHINA ZHICHENG TECHNOLOGY LTD.
    Whois Server: grs-whois.hichina.com
-   Referral URL: http://www.net.cn
+   Registrar URL: http://www.net.cn
 
    Server Name: GOOGLE.COM.HAS.LESS.FREE.PORN.IN.ITS.SEARCH.ENGINE.THAN.SECZY.COM
    IP Address: 209.187.114.130
    Registrar: TUCOWS DOMAINS INC.
    Whois Server: whois.tucows.com
-   Referral URL: http://domainhelp.opensrs.net
+   Registrar URL: http://domainhelp.opensrs.net
 
    Server Name: GOOGLE.COM.DO
    Registrar: GODADDY.COM, LLC
    Whois Server: whois.godaddy.com
-   Referral URL: http://registrar.godaddy.com
+   Registrar URL: http://registrar.godaddy.com
 
    Server Name: GOOGLE.COM.CO
    Registrar: NAMESECURE.COM
    Whois Server: whois.namesecure.com
-   Referral URL: http://www.namesecure.com
+   Registrar URL: http://www.namesecure.com
 
    Server Name: GOOGLE.COM.CN
    Registrar: XIN NET TECHNOLOGY CORPORATION
    Whois Server: whois.paycenter.com.cn
-   Referral URL: http://www.xinnet.com
+   Registrar URL: http://www.xinnet.com
 
    Server Name: GOOGLE.COM.BR
    Registrar: ENOM, INC.
    Whois Server: whois.enom.com
-   Referral URL: http://www.enom.com
+   Registrar URL: http://www.enom.com
 
    Server Name: GOOGLE.COM.BEYONDWHOIS.COM
    IP Address: 203.36.226.2
    Registrar: INSTRA CORPORATION PTY, LTD.
    Whois Server: whois.instra.net
-   Referral URL: http://www.instra.com
+   Registrar URL: http://www.instra.com
 
    Server Name: GOOGLE.COM.AU
    Registrar: PLANETDOMAIN PTY LTD.
    Whois Server: whois.planetdomain.com
-   Referral URL: http://www.planetdomain.com
+   Registrar URL: http://www.planetdomain.com
 
    Server Name: GOOGLE.COM.ARTVISUALRIO.COM
    IP Address: 200.222.44.35
    Registrar: ENOM, INC.
    Whois Server: whois.enom.com
-   Referral URL: http://www.enom.com
+   Registrar URL: http://www.enom.com
 
    Server Name: GOOGLE.COM.AR
    Registrar: ENOM, INC.
    Whois Server: whois.enom.com
-   Referral URL: http://www.enom.com
+   Registrar URL: http://www.enom.com
 
    Server Name: GOOGLE.COM.AFRICANBATS.ORG
    Registrar: TUCOWS DOMAINS INC.
    Whois Server: whois.tucows.com
-   Referral URL: http://domainhelp.opensrs.net
+   Registrar URL: http://domainhelp.opensrs.net
 
    Domain Name: GOOGLE.COM
    Registrar: MARKMONITOR INC.
    Whois Server: whois.markmonitor.com
-   Referral URL: http://www.markmonitor.com
+   Registrar URL: http://www.markmonitor.com
    Name Server: NS1.GOOGLE.COM
    Name Server: NS2.GOOGLE.COM
    Name Server: NS3.GOOGLE.COM
@@ -265,36 +265,36 @@ for detailed information.
 
 >>> Last update of whois database: Tue, 26 Nov 2013 17:41:54 UTC <<<
 
-NOTICE: The expiration date displayed in this record is the date the 
-registrar's sponsorship of the domain name registration in the registry is 
-currently set to expire. This date does not necessarily reflect the expiration 
-date of the domain name registrant's agreement with the sponsoring 
-registrar.  Users may consult the sponsoring registrar's Whois database to 
+NOTICE: The expiration date displayed in this record is the date the
+registrar's sponsorship of the domain name registration in the registry is
+currently set to expire. This date does not necessarily reflect the expiration
+date of the domain name registrant's agreement with the sponsoring
+registrar.  Users may consult the sponsoring registrar's Whois database to
 view the registrar's reported date of expiration for this registration.
 
-TERMS OF USE: You are not authorized to access or query our Whois 
-database through the use of electronic processes that are high-volume and 
-automated except as reasonably necessary to register domain names or 
-modify existing registrations; the Data in VeriSign Global Registry 
-Services' ("VeriSign") Whois database is provided by VeriSign for 
-information purposes only, and to assist persons in obtaining information 
-about or related to a domain name registration record. VeriSign does not 
-guarantee its accuracy. By submitting a Whois query, you agree to abide 
-by the following terms of use: You agree that you may use this Data only 
-for lawful purposes and that under no circumstances will you use this Data 
-to: (1) allow, enable, or otherwise support the transmission of mass 
-unsolicited, commercial advertising or solicitations via e-mail, telephone, 
-or facsimile; or (2) enable high volume, automated, electronic processes 
-that apply to VeriSign (or its computer systems). The compilation, 
-repackaging, dissemination or other use of this Data is expressly 
-prohibited without the prior written consent of VeriSign. You agree not to 
-use electronic processes that are automated and high-volume to access or 
-query the Whois database except as reasonably necessary to register 
-domain names or modify existing registrations. VeriSign reserves the right 
-to restrict your access to the Whois database in its sole discretion to ensure 
-operational stability.  VeriSign may restrict or terminate your access to the 
-Whois database for failure to abide by these terms of use. VeriSign 
-reserves the right to modify these terms at any time. 
+TERMS OF USE: You are not authorized to access or query our Whois
+database through the use of electronic processes that are high-volume and
+automated except as reasonably necessary to register domain names or
+modify existing registrations; the Data in VeriSign Global Registry
+Services' ("VeriSign") Whois database is provided by VeriSign for
+information purposes only, and to assist persons in obtaining information
+about or related to a domain name registration record. VeriSign does not
+guarantee its accuracy. By submitting a Whois query, you agree to abide
+by the following terms of use: You agree that you may use this Data only
+for lawful purposes and that under no circumstances will you use this Data
+to: (1) allow, enable, or otherwise support the transmission of mass
+unsolicited, commercial advertising or solicitations via e-mail, telephone,
+or facsimile; or (2) enable high volume, automated, electronic processes
+that apply to VeriSign (or its computer systems). The compilation,
+repackaging, dissemination or other use of this Data is expressly
+prohibited without the prior written consent of VeriSign. You agree not to
+use electronic processes that are automated and high-volume to access or
+query the Whois database except as reasonably necessary to register
+domain names or modify existing registrations. VeriSign reserves the right
+to restrict your access to the Whois database in its sole discretion to ensure
+operational stability.  VeriSign may restrict or terminate your access to the
+Whois database for failure to abide by these terms of use. VeriSign
+reserves the right to modify these terms at any time.
 
 The Registry database contains ONLY .COM, .NET, .EDU domains and
 Registrars.

--- a/spec/fixtures/responses/whois.verisign-grs.com/com/status_registered.txt
+++ b/spec/fixtures/responses/whois.verisign-grs.com/com/status_registered.txt
@@ -1,305 +1,60 @@
-
-Whois Server Version 2.0
-
-Domain names in the .com and .net domains can now be registered
-with many different competing registrars. Go to http://www.internic.net
-for detailed information.
-
-   Server Name: GOOGLE.COM.ZZZZZZZZZZZZZZZZZZZZZZZZZZ.HAVENDATA.COM
-   IP Address: 50.23.75.44
-   Registrar: PDR LTD. D/B/A PUBLICDOMAINREGISTRY.COM
-   Whois Server: whois.PublicDomainRegistry.com
-   Referral URL: http://www.PublicDomainRegistry.com
-
-   Server Name: GOOGLE.COM.ZZZZZZZZZZZZZ.GET.ONE.MILLION.DOLLARS.AT.WWW.UNIMUNDI.COM
-   IP Address: 209.126.190.70
-   Registrar: PDR LTD. D/B/A PUBLICDOMAINREGISTRY.COM
-   Whois Server: whois.PublicDomainRegistry.com
-   Referral URL: http://www.PublicDomainRegistry.com
-
-   Server Name: GOOGLE.COM.ZZZZZ.GET.LAID.AT.WWW.SWINGINGCOMMUNITY.COM
-   IP Address: 69.41.185.195
-   Registrar: TUCOWS DOMAINS INC.
-   Whois Server: whois.tucows.com
-   Referral URL: http://domainhelp.opensrs.net
-
-   Server Name: GOOGLE.COM.ZOMBIED.AND.HACKED.BY.WWW.WEB-HACK.COM
-   IP Address: 217.107.217.167
-   Registrar: DOMAINCONTEXT, INC.
-   Whois Server: whois.domaincontext.com
-   Referral URL: http://www.domaincontext.com
-
-   Server Name: GOOGLE.COM.ZNAET.PRODOMEN.COM
-   IP Address: 62.149.23.126
-   Registrar: PDR LTD. D/B/A PUBLICDOMAINREGISTRY.COM
-   Whois Server: whois.PublicDomainRegistry.com
-   Referral URL: http://www.PublicDomainRegistry.com
-
-   Server Name: GOOGLE.COM.YUCEKIRBAC.COM
-   IP Address: 88.246.115.134
-   Registrar: PDR LTD. D/B/A PUBLICDOMAINREGISTRY.COM
-   Whois Server: whois.PublicDomainRegistry.com
-   Referral URL: http://www.PublicDomainRegistry.com
-
-   Server Name: GOOGLE.COM.YUCEHOCA.COM
-   IP Address: 88.246.115.134
-   Registrar: PDR LTD. D/B/A PUBLICDOMAINREGISTRY.COM
-   Whois Server: whois.PublicDomainRegistry.com
-   Referral URL: http://www.PublicDomainRegistry.com
-
-   Server Name: GOOGLE.COM.WORDT.DOOR.VEEL.WHTERS.GEBRUIKT.SERVERTJE.NET
-   IP Address: 62.41.27.144
-   Registrar: KEY-SYSTEMS GMBH
-   Whois Server: whois.rrpproxy.net
-   Referral URL: http://www.key-systems.net
-
-   Server Name: GOOGLE.COM.VN
-   Registrar: ONLINENIC, INC.
-   Whois Server: whois.onlinenic.com
-   Referral URL: http://www.OnlineNIC.com
-
-   Server Name: GOOGLE.COM.VABDAYOFF.COM
-   IP Address: 8.8.8.8
-   Registrar: DOMAIN.COM, LLC
-   Whois Server: whois.domain.com
-   Referral URL: http://www.domain.com
-
-   Server Name: GOOGLE.COM.UY
-   Registrar: PDR LTD. D/B/A PUBLICDOMAINREGISTRY.COM
-   Whois Server: whois.PublicDomainRegistry.com
-   Referral URL: http://www.PublicDomainRegistry.com
-
-   Server Name: GOOGLE.COM.UA
-   Registrar: PDR LTD. D/B/A PUBLICDOMAINREGISTRY.COM
-   Whois Server: whois.PublicDomainRegistry.com
-   Referral URL: http://www.PublicDomainRegistry.com
-
-   Server Name: GOOGLE.COM.TW
-   Registrar: WEB COMMERCE COMMUNICATIONS LIMITED DBA WEBNIC.CC
-   Whois Server: whois.webnic.cc
-   Referral URL: http://www.webnic.cc
-
-   Server Name: GOOGLE.COM.TR
-   Registrar: PDR LTD. D/B/A PUBLICDOMAINREGISTRY.COM
-   Whois Server: whois.PublicDomainRegistry.com
-   Referral URL: http://www.PublicDomainRegistry.com
-
-   Server Name: GOOGLE.COM.SUCKS.FIND.CRACKZ.WITH.SEARCH.GULLI.COM
-   IP Address: 80.190.192.24
-   Registrar: COREHUB, S.R.L.
-   Whois Server: whois.corehub.net
-   Referral URL: http://www.corehub.net
-
-   Server Name: GOOGLE.COM.SPROSIUYANDEKSA.RU
-   Registrar: MELBOURNE IT, LTD. D/B/A INTERNET NAMES WORLDWIDE
-   Whois Server: whois.melbourneit.com
-   Referral URL: http://www.melbourneit.com
-
-   Server Name: GOOGLE.COM.SPAMMING.IS.UNETHICAL.PLEASE.STOP.THEM.HUAXUEERBAN.COM
-   IP Address: 211.64.175.66
-   IP Address: 211.64.175.67
-   Registrar: GODADDY.COM, LLC
-   Whois Server: whois.godaddy.com
-   Referral URL: http://registrar.godaddy.com
-
-   Server Name: GOOGLE.COM.SOUTHBEACHNEEDLEARTISTRY.COM
-   IP Address: 74.125.229.52
-   Registrar: GODADDY.COM, LLC
-   Whois Server: whois.godaddy.com
-   Referral URL: http://registrar.godaddy.com
-
-   Server Name: GOOGLE.COM.SHQIPERIA.COM
-   IP Address: 70.84.145.107
-   Registrar: ENOM, INC.
-   Whois Server: whois.enom.com
-   Referral URL: http://www.enom.com
-
-   Server Name: GOOGLE.COM.SA
-   Registrar: OMNIS NETWORK, LLC
-   Whois Server: whois.omnis.com
-   Referral URL: http://domains.omnis.com
-
-   Server Name: GOOGLE.COM.PK
-   Registrar: BIGROCK SOLUTIONS LIMITED
-   Whois Server: Whois.bigrock.com
-   Referral URL: http://www.bigrock.com
-
-   Server Name: GOOGLE.COM.PE
-   Registrar: PDR LTD. D/B/A PUBLICDOMAINREGISTRY.COM
-   Whois Server: whois.PublicDomainRegistry.com
-   Referral URL: http://www.PublicDomainRegistry.com
-
-   Server Name: GOOGLE.COM.NS2.CHALESHGAR.COM
-   IP Address: 8.8.8.8
-   Registrar: REALTIME REGISTER BV
-   Whois Server: whois.yoursrs.com
-   Referral URL: http://www.realtimeregister.com
-
-   Server Name: GOOGLE.COM.NS1.CHALESHGAR.COM
-   IP Address: 8.8.8.8
-   Registrar: REALTIME REGISTER BV
-   Whois Server: whois.yoursrs.com
-   Referral URL: http://www.realtimeregister.com
-
-   Server Name: GOOGLE.COM.MY
-   Registrar: WILD WEST DOMAINS, LLC
-   Whois Server: whois.wildwestdomains.com
-   Referral URL: http://www.wildwestdomains.com
-
-   Server Name: GOOGLE.COM.MX
-   Registrar: PDR LTD. D/B/A PUBLICDOMAINREGISTRY.COM
-   Whois Server: whois.PublicDomainRegistry.com
-   Referral URL: http://www.PublicDomainRegistry.com
-
-   Server Name: GOOGLE.COM.LOLOLOLOLOL.SHTHEAD.COM
-   IP Address: 123.123.123.123
-   Registrar: CRAZY DOMAINS FZ-LLC
-   Whois Server: whois.crazydomains.com
-   Referral URL: http://www.crazydomains.com 
-
-   Server Name: GOOGLE.COM.LASERPIPE.COM
-   IP Address: 209.85.227.106
-   Registrar: REALTIME REGISTER BV
-   Whois Server: whois.yoursrs.com
-   Referral URL: http://www.realtimeregister.com
-
-   Server Name: GOOGLE.COM.IS.NOT.HOSTED.BY.ACTIVEDOMAINDNS.NET
-   IP Address: 217.148.161.5
-   Registrar: ENOM, INC.
-   Whois Server: whois.enom.com
-   Referral URL: http://www.enom.com
-
-   Server Name: GOOGLE.COM.IS.HOSTED.ON.PROFITHOSTING.NET
-   IP Address: 66.49.213.213
-   Registrar: NAME.COM, INC.
-   Whois Server: whois.name.com
-   Referral URL: http://www.name.com
-
-   Server Name: GOOGLE.COM.IS.APPROVED.BY.NUMEA.COM
-   IP Address: 213.228.0.43
-   Registrar: GANDI SAS
-   Whois Server: whois.gandi.net
-   Referral URL: http://www.gandi.net
-
-   Server Name: GOOGLE.COM.HK
-   Registrar: CLOUD GROUP LIMITED
-   Whois Server: whois.hostingservicesinc.net
-   Referral URL: http://www.resell.biz
-
-   Server Name: GOOGLE.COM.HAS.LESS.FREE.PORN.IN.ITS.SEARCH.ENGINE.THAN.SECZY.COM
-   IP Address: 209.187.114.130
-   Registrar: TUCOWS DOMAINS INC.
-   Whois Server: whois.tucows.com
-   Referral URL: http://domainhelp.opensrs.net
-
-   Server Name: GOOGLE.COM.HACKED.BY.JAPTRON.ES
-   Registrar: GODADDY.COM, LLC
-   Whois Server: whois.godaddy.com
-   Referral URL: http://registrar.godaddy.com
-
-   Server Name: GOOGLE.COM.FIBERTREAT.COM
-   IP Address: 64.233.160.5
-   Registrar: GODADDY.COM, LLC
-   Whois Server: whois.godaddy.com
-   Referral URL: http://registrar.godaddy.com
-
-   Server Name: GOOGLE.COM.DO
-   Registrar: GODADDY.COM, LLC
-   Whois Server: whois.godaddy.com
-   Referral URL: http://registrar.godaddy.com
-
-   Server Name: GOOGLE.COM.CO
-   Registrar: NAMESECURE.COM
-   Whois Server: whois.namesecure.com
-   Referral URL: http://www.namesecure.com
-
-   Server Name: GOOGLE.COM.CN
-   Registrar: XIN NET TECHNOLOGY CORPORATION
-   Whois Server: whois.paycenter.com.cn
-   Referral URL: http://www.xinnet.com
-
-   Server Name: GOOGLE.COM.BR
-   Registrar: ENOM, INC.
-   Whois Server: whois.enom.com
-   Referral URL: http://www.enom.com
-
-   Server Name: GOOGLE.COM.BEYONDWHOIS.COM
-   IP Address: 203.36.226.2
-   Registrar: INSTRA CORPORATION PTY, LTD.
-   Whois Server: whois.instra.net
-   Referral URL: http://www.instra.com
-
-   Server Name: GOOGLE.COM.AU
-   Registrar: PLANETDOMAIN PTY LTD.
-   Whois Server: whois.planetdomain.com
-   Referral URL: http://www.planetdomain.com
-
-   Server Name: GOOGLE.COM.ARTVISUALRIO.COM
-   IP Address: 200.222.44.35
-   Registrar: ENOM, INC.
-   Whois Server: whois.enom.com
-   Referral URL: http://www.enom.com
-
-   Server Name: GOOGLE.COM.AR
-   Registrar: ENOM, INC.
-   Whois Server: whois.enom.com
-   Referral URL: http://www.enom.com
-
-   Server Name: GOOGLE.COM.AFRICANBATS.ORG
-   Registrar: TUCOWS DOMAINS INC.
-   Whois Server: whois.tucows.com
-   Referral URL: http://domainhelp.opensrs.net
-
    Domain Name: GOOGLE.COM
-   Registrar: MARKMONITOR INC.
-   Whois Server: whois.markmonitor.com
-   Referral URL: http://www.markmonitor.com
+   Registry Domain ID: 2138514_DOMAIN_COM-VRSN
+   Registrar WHOIS Server: whois.markmonitor.com
+   Registrar URL: http://www.markmonitor.com
+   Updated Date: 2011-07-20T16:55:31Z
+   Creation Date: 1997-09-15T04:00:00Z
+   Registry Expiry Date: 2020-09-14T04:00:00Z
+   Registrar: MarkMonitor Inc.
+   Registrar IANA ID: 292
+   Registrar Abuse Contact Email: abusecomplaints@markmonitor.com
+   Registrar Abuse Contact Phone: +1.2083895740
+   Domain Status: clientDeleteProhibited https://icann.org/epp#clientDeleteProhibited
+   Domain Status: clientTransferProhibited https://icann.org/epp#clientTransferProhibited
+   Domain Status: clientUpdateProhibited https://icann.org/epp#clientUpdateProhibited
+   Domain Status: serverDeleteProhibited https://icann.org/epp#serverDeleteProhibited
+   Domain Status: serverTransferProhibited https://icann.org/epp#serverTransferProhibited
+   Domain Status: serverUpdateProhibited https://icann.org/epp#serverUpdateProhibited
    Name Server: NS1.GOOGLE.COM
    Name Server: NS2.GOOGLE.COM
    Name Server: NS3.GOOGLE.COM
    Name Server: NS4.GOOGLE.COM
-   Status: clientDeleteProhibited
-   Status: clientTransferProhibited
-   Status: clientUpdateProhibited
-   Status: serverDeleteProhibited
-   Status: serverTransferProhibited
-   Status: serverUpdateProhibited
-   Updated Date: 20-jul-2011
-   Creation Date: 15-sep-1997
-   Expiration Date: 14-sep-2020
+   DNSSEC: unsigned
+   URL of the ICANN Whois Inaccuracy Complaint Form: https://www.icann.org/wicf/
+>>> Last update of whois database: 2017-07-31T23:59:53Z <<<
 
->>> Last update of whois database: Tue, 18 Mar 2014 13:37:06 UTC <<<
+For more information on Whois status codes, please visit https://icann.org/epp
 
-NOTICE: The expiration date displayed in this record is the date the 
-registrar's sponsorship of the domain name registration in the registry is 
-currently set to expire. This date does not necessarily reflect the expiration 
-date of the domain name registrant's agreement with the sponsoring 
-registrar.  Users may consult the sponsoring registrar's Whois database to 
+NOTICE: The expiration date displayed in this record is the date the
+registrar's sponsorship of the domain name registration in the registry is
+currently set to expire. This date does not necessarily reflect the expiration
+date of the domain name registrant's agreement with the sponsoring
+registrar.  Users may consult the sponsoring registrar's Whois database to
 view the registrar's reported date of expiration for this registration.
 
-TERMS OF USE: You are not authorized to access or query our Whois 
-database through the use of electronic processes that are high-volume and 
-automated except as reasonably necessary to register domain names or 
-modify existing registrations; the Data in VeriSign Global Registry 
-Services' ("VeriSign") Whois database is provided by VeriSign for 
-information purposes only, and to assist persons in obtaining information 
-about or related to a domain name registration record. VeriSign does not 
-guarantee its accuracy. By submitting a Whois query, you agree to abide 
-by the following terms of use: You agree that you may use this Data only 
-for lawful purposes and that under no circumstances will you use this Data 
-to: (1) allow, enable, or otherwise support the transmission of mass 
-unsolicited, commercial advertising or solicitations via e-mail, telephone, 
-or facsimile; or (2) enable high volume, automated, electronic processes 
-that apply to VeriSign (or its computer systems). The compilation, 
-repackaging, dissemination or other use of this Data is expressly 
-prohibited without the prior written consent of VeriSign. You agree not to 
-use electronic processes that are automated and high-volume to access or 
-query the Whois database except as reasonably necessary to register 
-domain names or modify existing registrations. VeriSign reserves the right 
-to restrict your access to the Whois database in its sole discretion to ensure 
-operational stability.  VeriSign may restrict or terminate your access to the 
-Whois database for failure to abide by these terms of use. VeriSign 
-reserves the right to modify these terms at any time. 
+TERMS OF USE: You are not authorized to access or query our Whois
+database through the use of electronic processes that are high-volume and
+automated except as reasonably necessary to register domain names or
+modify existing registrations; the Data in VeriSign Global Registry
+Services' ("VeriSign") Whois database is provided by VeriSign for
+information purposes only, and to assist persons in obtaining information
+about or related to a domain name registration record. VeriSign does not
+guarantee its accuracy. By submitting a Whois query, you agree to abide
+by the following terms of use: You agree that you may use this Data only
+for lawful purposes and that under no circumstances will you use this Data
+to: (1) allow, enable, or otherwise support the transmission of mass
+unsolicited, commercial advertising or solicitations via e-mail, telephone,
+or facsimile; or (2) enable high volume, automated, electronic processes
+that apply to VeriSign (or its computer systems). The compilation,
+repackaging, dissemination or other use of this Data is expressly
+prohibited without the prior written consent of VeriSign. You agree not to
+use electronic processes that are automated and high-volume to access or
+query the Whois database except as reasonably necessary to register
+domain names or modify existing registrations. VeriSign reserves the right
+to restrict your access to the Whois database in its sole discretion to ensure
+operational stability.  VeriSign may restrict or terminate your access to the
+Whois database for failure to abide by these terms of use. VeriSign
+reserves the right to modify these terms at any time.
 
 The Registry database contains ONLY .COM, .NET, .EDU domains and
 Registrars.

--- a/spec/fixtures/responses/whois.verisign-grs.com/net/status_registered.txt
+++ b/spec/fixtures/responses/whois.verisign-grs.com/net/status_registered.txt
@@ -1,60 +1,60 @@
-
-Whois Server Version 2.0
-
-Domain names in the .com and .net domains can now be registered
-with many different competing registrars. Go to http://www.internic.net
-for detailed information.
-
    Domain Name: GOOGLE.NET
-   Registrar: MARKMONITOR INC.
-   Whois Server: whois.markmonitor.com
-   Referral URL: http://www.markmonitor.com
+   Registry Domain ID: 4802712_DOMAIN_NET-VRSN
+   Registrar WHOIS Server: whois.markmonitor.com
+   Registrar URL: http://www.markmonitor.com
+   Updated Date: 2017-02-11T10:56:37Z
+   Creation Date: 1999-03-15T05:00:00Z
+   Registry Expiry Date: 2018-03-15T04:00:00Z
+   Registrar: MarkMonitor Inc.
+   Registrar IANA ID: 292
+   Registrar Abuse Contact Email: abusecomplaints@markmonitor.com
+   Registrar Abuse Contact Phone: +1.2083895740
+   Domain Status: clientDeleteProhibited https://icann.org/epp#clientDeleteProhibited
+   Domain Status: clientTransferProhibited https://icann.org/epp#clientTransferProhibited
+   Domain Status: clientUpdateProhibited https://icann.org/epp#clientUpdateProhibited
+   Domain Status: serverDeleteProhibited https://icann.org/epp#serverDeleteProhibited
+   Domain Status: serverTransferProhibited https://icann.org/epp#serverTransferProhibited
+   Domain Status: serverUpdateProhibited https://icann.org/epp#serverUpdateProhibited
    Name Server: NS1.GOOGLE.COM
    Name Server: NS2.GOOGLE.COM
    Name Server: NS3.GOOGLE.COM
    Name Server: NS4.GOOGLE.COM
-   Status: clientDeleteProhibited
-   Status: clientTransferProhibited
-   Status: clientUpdateProhibited
-   Status: serverDeleteProhibited
-   Status: serverTransferProhibited
-   Status: serverUpdateProhibited
-   Updated Date: 11-feb-2014
-   Creation Date: 15-mar-1999
-   Expiration Date: 15-mar-2015
+   DNSSEC: unsigned
+   URL of the ICANN Whois Inaccuracy Complaint Form: https://www.icann.org/wicf/
+>>> Last update of whois database: 2017-08-01T01:39:40Z <<<
 
->>> Last update of whois database: Tue, 18 Mar 2014 13:37:06 UTC <<<
+For more information on Whois status codes, please visit https://icann.org/epp
 
-NOTICE: The expiration date displayed in this record is the date the 
-registrar's sponsorship of the domain name registration in the registry is 
-currently set to expire. This date does not necessarily reflect the expiration 
-date of the domain name registrant's agreement with the sponsoring 
-registrar.  Users may consult the sponsoring registrar's Whois database to 
+NOTICE: The expiration date displayed in this record is the date the
+registrar's sponsorship of the domain name registration in the registry is
+currently set to expire. This date does not necessarily reflect the expiration
+date of the domain name registrant's agreement with the sponsoring
+registrar.  Users may consult the sponsoring registrar's Whois database to
 view the registrar's reported date of expiration for this registration.
 
-TERMS OF USE: You are not authorized to access or query our Whois 
-database through the use of electronic processes that are high-volume and 
-automated except as reasonably necessary to register domain names or 
-modify existing registrations; the Data in VeriSign Global Registry 
-Services' ("VeriSign") Whois database is provided by VeriSign for 
-information purposes only, and to assist persons in obtaining information 
-about or related to a domain name registration record. VeriSign does not 
-guarantee its accuracy. By submitting a Whois query, you agree to abide 
-by the following terms of use: You agree that you may use this Data only 
-for lawful purposes and that under no circumstances will you use this Data 
-to: (1) allow, enable, or otherwise support the transmission of mass 
-unsolicited, commercial advertising or solicitations via e-mail, telephone, 
-or facsimile; or (2) enable high volume, automated, electronic processes 
-that apply to VeriSign (or its computer systems). The compilation, 
-repackaging, dissemination or other use of this Data is expressly 
-prohibited without the prior written consent of VeriSign. You agree not to 
-use electronic processes that are automated and high-volume to access or 
-query the Whois database except as reasonably necessary to register 
-domain names or modify existing registrations. VeriSign reserves the right 
-to restrict your access to the Whois database in its sole discretion to ensure 
-operational stability.  VeriSign may restrict or terminate your access to the 
-Whois database for failure to abide by these terms of use. VeriSign 
-reserves the right to modify these terms at any time. 
+TERMS OF USE: You are not authorized to access or query our Whois
+database through the use of electronic processes that are high-volume and
+automated except as reasonably necessary to register domain names or
+modify existing registrations; the Data in VeriSign Global Registry
+Services' ("VeriSign") Whois database is provided by VeriSign for
+information purposes only, and to assist persons in obtaining information
+about or related to a domain name registration record. VeriSign does not
+guarantee its accuracy. By submitting a Whois query, you agree to abide
+by the following terms of use: You agree that you may use this Data only
+for lawful purposes and that under no circumstances will you use this Data
+to: (1) allow, enable, or otherwise support the transmission of mass
+unsolicited, commercial advertising or solicitations via e-mail, telephone,
+or facsimile; or (2) enable high volume, automated, electronic processes
+that apply to VeriSign (or its computer systems). The compilation,
+repackaging, dissemination or other use of this Data is expressly
+prohibited without the prior written consent of VeriSign. You agree not to
+use electronic processes that are automated and high-volume to access or
+query the Whois database except as reasonably necessary to register
+domain names or modify existing registrations. VeriSign reserves the right
+to restrict your access to the Whois database in its sole discretion to ensure
+operational stability.  VeriSign may restrict or terminate your access to the
+Whois database for failure to abide by these terms of use. VeriSign
+reserves the right to modify these terms at any time.
 
 The Registry database contains ONLY .COM, .NET, .EDU domains and
 Registrars.

--- a/spec/whois/parsers/responses/ccwhois.verisign-grs.com/cc/status_registered_spec.rb
+++ b/spec/whois/parsers/responses/ccwhois.verisign-grs.com/cc/status_registered_spec.rb
@@ -33,7 +33,7 @@ describe Whois::Parsers::CcwhoisVerisignGrsCom, "status_registered.expected" do
   end
   describe "#domain_id" do
     it do
-      expect(subject.domain_id).to eq("86420657")
+      expect(subject.domain_id).to eq("86420657_DOMAIN_CC-VRSN")
     end
   end
   describe "#status" do
@@ -54,19 +54,19 @@ describe Whois::Parsers::CcwhoisVerisignGrsCom, "status_registered.expected" do
   describe "#created_on" do
     it do
       expect(subject.created_on).to be_a(Time)
-      expect(subject.created_on).to eq(Time.parse("1999-06-07 00:00:00 UTC"))
+      expect(subject.created_on).to eq(Time.parse("1999-06-07 04:00:00 UTC"))
     end
   end
   describe "#updated_on" do
     it do
       expect(subject.updated_on).to be_a(Time)
-      expect(subject.updated_on).to eq(Time.parse("2013-05-06 05:17:44 UTC"))
+      expect(subject.updated_on).to eq(Time.parse("2017-05-06 09:28:40 UTC"))
     end
   end
   describe "#expires_on" do
     it do
       expect(subject.expires_on).to be_a(Time)
-      expect(subject.expires_on).to eq(Time.parse("2014-06-07 00:00:00 UTC"))
+      expect(subject.expires_on).to eq(Time.parse("2018-06-07 04:00:00 UTC"))
     end
   end
   describe "#registrar" do

--- a/spec/whois/parsers/responses/tvwhois.verisign-grs.com/tv/status_registered_spec.rb
+++ b/spec/whois/parsers/responses/tvwhois.verisign-grs.com/tv/status_registered_spec.rb
@@ -33,7 +33,7 @@ describe Whois::Parsers::TvwhoisVerisignGrsCom, "status_registered.expected" do
   end
   describe "#domain_id" do
     it do
-      expect(subject.domain_id).to eq("87196881")
+      expect(subject.domain_id).to eq("87196881_DOMAIN_TV-VRSN")
     end
   end
   describe "#status" do
@@ -54,28 +54,28 @@ describe Whois::Parsers::TvwhoisVerisignGrsCom, "status_registered.expected" do
   describe "#created_on" do
     it do
       expect(subject.created_on).to be_a(Time)
-      expect(subject.created_on).to eq(Time.parse("2002-08-02 12:43:36 UTC"))
+      expect(subject.created_on).to eq(Time.parse("2002-08-02 16:43:36 UTC"))
     end
   end
   describe "#updated_on" do
     it do
       expect(subject.updated_on).to be_a(Time)
-      expect(subject.updated_on).to eq(Time.parse("2013-07-09 17:03:47 UTC"))
+      expect(subject.updated_on).to eq(Time.parse("2017-07-01 09:25:47 UTC"))
     end
   end
   describe "#expires_on" do
     it do
       expect(subject.expires_on).to be_a(Time)
-      expect(subject.expires_on).to eq(Time.parse("2014-08-02 12:43:36 UTC"))
+      expect(subject.expires_on).to eq(Time.parse("2018-08-02 16:43:36 UTC"))
     end
   end
   describe "#registrar" do
     it do
       expect(subject.registrar).to be_a(Whois::Parser::Registrar)
-      expect(subject.registrar.id).to eq("48")
-      expect(subject.registrar.name).to eq("ENOM, INC.")
+      expect(subject.registrar.id).to eq("292")
+      expect(subject.registrar.name).to eq("MARKMONITOR INC.")
       expect(subject.registrar.organization).to eq(nil)
-      expect(subject.registrar.url).to eq("http://www.enom.com")
+      expect(subject.registrar.url).to eq("http://www.markmonitor.com")
     end
   end
   describe "#nameservers" do
@@ -98,12 +98,12 @@ describe Whois::Parsers::TvwhoisVerisignGrsCom, "status_registered.expected" do
   end
   describe "#referral_whois" do
     it do
-      expect(subject.referral_whois).to eq("whois.enom.com")
+      expect(subject.referral_whois).to eq("whois.markmonitor.com")
     end
   end
   describe "#referral_url" do
     it do
-      expect(subject.referral_url).to eq("http://www.enom.com")
+      expect(subject.referral_url).to eq("http://www.markmonitor.com")
     end
   end
 end

--- a/spec/whois/parsers/responses/whois.nic.jobs/jobs/status_registered_spec.rb
+++ b/spec/whois/parsers/responses/whois.nic.jobs/jobs/status_registered_spec.rb
@@ -33,7 +33,7 @@ describe Whois::Parsers::WhoisNicJobs, "status_registered.expected" do
   end
   describe "#domain_id" do
     it do
-      expect(subject.domain_id).to eq("86932313")
+      expect(subject.domain_id).to eq("86932313_DOMAIN_JOBS-VRSN")
     end
   end
   describe "#status" do
@@ -54,19 +54,19 @@ describe Whois::Parsers::WhoisNicJobs, "status_registered.expected" do
   describe "#created_on" do
     it do
       expect(subject.created_on).to be_a(Time)
-      expect(subject.created_on).to eq(Time.parse("2005-09-15 00:00:00 UTC"))
+      expect(subject.created_on).to eq(Time.parse("2005-09-15 04:00:00 UTC"))
     end
   end
   describe "#updated_on" do
     it do
       expect(subject.updated_on).to be_a(Time)
-      expect(subject.updated_on).to eq(Time.parse("2013-08-14 05:20:33 UTC"))
+      expect(subject.updated_on).to eq(Time.parse("2017-07-27 20:59:01 UTC"))
     end
   end
   describe "#expires_on" do
     it do
       expect(subject.expires_on).to be_a(Time)
-      expect(subject.expires_on).to eq(Time.parse("2014-09-15 00:00:00 UTC"))
+      expect(subject.expires_on).to eq(Time.parse("2017-09-15 04:00:00 UTC"))
     end
   end
   describe "#registrar" do

--- a/spec/whois/parsers/responses/whois.verisign-grs.com/com/status_registered_spec.rb
+++ b/spec/whois/parsers/responses/whois.verisign-grs.com/com/status_registered_spec.rb
@@ -54,26 +54,26 @@ describe Whois::Parsers::WhoisVerisignGrsCom, "status_registered.expected" do
   describe "#created_on" do
     it do
       expect(subject.created_on).to be_a(Time)
-      expect(subject.created_on).to eq(Time.parse("1997-09-15"))
+      expect(subject.created_on).to eq(Time.parse("1997-09-15T04:00:00Z"))
     end
   end
   describe "#updated_on" do
     it do
       expect(subject.updated_on).to be_a(Time)
-      expect(subject.updated_on).to eq(Time.parse("2011-07-20"))
+      expect(subject.updated_on).to eq(Time.parse("2011-07-20T16:55:31Z"))
     end
   end
   describe "#expires_on" do
     it do
       expect(subject.expires_on).to be_a(Time)
-      expect(subject.expires_on).to eq(Time.parse("2020-09-14"))
+      expect(subject.expires_on).to eq(Time.parse("2020-09-14T04:00:00Z"))
     end
   end
   describe "#registrar" do
     it do
       expect(subject.registrar).to be_a(Whois::Parser::Registrar)
       expect(subject.registrar.id).to eq(nil)
-      expect(subject.registrar.name).to eq("MARKMONITOR INC.")
+      expect(subject.registrar.name).to eq("MarkMonitor Inc.")
       expect(subject.registrar.organization).to eq(nil)
       expect(subject.registrar.url).to eq("http://www.markmonitor.com")
     end

--- a/spec/whois/parsers/responses/whois.verisign-grs.com/com/status_registered_spec.rb
+++ b/spec/whois/parsers/responses/whois.verisign-grs.com/com/status_registered_spec.rb
@@ -33,7 +33,7 @@ describe Whois::Parsers::WhoisVerisignGrsCom, "status_registered.expected" do
   end
   describe "#domain_id" do
     it do
-      expect(subject.domain_id).to eq(nil)
+      expect(subject.domain_id).to eq("2138514_DOMAIN_COM-VRSN")
     end
   end
   describe "#status" do
@@ -72,7 +72,7 @@ describe Whois::Parsers::WhoisVerisignGrsCom, "status_registered.expected" do
   describe "#registrar" do
     it do
       expect(subject.registrar).to be_a(Whois::Parser::Registrar)
-      expect(subject.registrar.id).to eq(nil)
+      expect(subject.registrar.id).to eq("292")
       expect(subject.registrar.name).to eq("MarkMonitor Inc.")
       expect(subject.registrar.organization).to eq(nil)
       expect(subject.registrar.url).to eq("http://www.markmonitor.com")
@@ -102,7 +102,7 @@ describe Whois::Parsers::WhoisVerisignGrsCom, "status_registered.expected" do
   end
   describe "#referral_whois" do
     it do
-      expect(subject.referral_whois).to eq(["whois.PublicDomainRegistry.com", "whois.PublicDomainRegistry.com", "whois.tucows.com", "whois.domaincontext.com", "whois.PublicDomainRegistry.com", "whois.PublicDomainRegistry.com", "whois.PublicDomainRegistry.com", "whois.rrpproxy.net", "whois.onlinenic.com", "whois.domain.com", "whois.PublicDomainRegistry.com", "whois.PublicDomainRegistry.com", "whois.webnic.cc", "whois.PublicDomainRegistry.com", "whois.corehub.net", "whois.melbourneit.com", "whois.godaddy.com", "whois.godaddy.com", "whois.enom.com", "whois.omnis.com", "Whois.bigrock.com", "whois.PublicDomainRegistry.com", "whois.yoursrs.com", "whois.yoursrs.com", "whois.wildwestdomains.com", "whois.PublicDomainRegistry.com", "whois.crazydomains.com", "whois.yoursrs.com", "whois.enom.com", "whois.name.com", "whois.gandi.net", "whois.hostingservicesinc.net", "whois.tucows.com", "whois.godaddy.com", "whois.godaddy.com", "whois.godaddy.com", "whois.namesecure.com", "whois.paycenter.com.cn", "whois.enom.com", "whois.instra.net", "whois.planetdomain.com", "whois.enom.com", "whois.enom.com", "whois.tucows.com", "whois.markmonitor.com"])
+      expect(subject.referral_whois).to eq("whois.markmonitor.com")
     end
   end
   describe "#referral_url" do

--- a/spec/whois/parsers/responses/whois.verisign-grs.com/net/status_registered_spec.rb
+++ b/spec/whois/parsers/responses/whois.verisign-grs.com/net/status_registered_spec.rb
@@ -33,7 +33,7 @@ describe Whois::Parsers::WhoisVerisignGrsCom, "status_registered.expected" do
   end
   describe "#domain_id" do
     it do
-      expect(subject.domain_id).to eq(nil)
+      expect(subject.domain_id).to eq("4802712_DOMAIN_NET-VRSN")
     end
   end
   describe "#status" do
@@ -54,26 +54,26 @@ describe Whois::Parsers::WhoisVerisignGrsCom, "status_registered.expected" do
   describe "#created_on" do
     it do
       expect(subject.created_on).to be_a(Time)
-      expect(subject.created_on).to eq(Time.parse("1999-03-15"))
+      expect(subject.created_on).to eq(Time.parse("1999-03-15 05:00:00 UTC"))
     end
   end
   describe "#updated_on" do
     it do
       expect(subject.updated_on).to be_a(Time)
-      expect(subject.updated_on).to eq(Time.parse("2014-02-11"))
+      expect(subject.updated_on).to eq(Time.parse("2017-02-11 10:56:37 UTC"))
     end
   end
   describe "#expires_on" do
     it do
       expect(subject.expires_on).to be_a(Time)
-      expect(subject.expires_on).to eq(Time.parse("2015-03-15"))
+      expect(subject.expires_on).to eq(Time.parse("2018-03-15 04:00:00 UTC"))
     end
   end
   describe "#registrar" do
     it do
       expect(subject.registrar).to be_a(Whois::Parser::Registrar)
-      expect(subject.registrar.id).to eq(nil)
-      expect(subject.registrar.name).to eq("MARKMONITOR INC.")
+      expect(subject.registrar.id).to eq("292")
+      expect(subject.registrar.name).to eq("MarkMonitor Inc.")
       expect(subject.registrar.organization).to eq(nil)
       expect(subject.registrar.url).to eq("http://www.markmonitor.com")
     end


### PR DESCRIPTION
It appears verisign has updated the wording for the expiry date for .com domains
Confimed with: 
```
# whois -h whois.verisign-grs.com google.com
   Domain Name: GOOGLE.COM
...
   Registry Expiry Date: 2020-09-14T04:00:00Z
...

```