### PR TITLE
Fix expires_on method for whois.verisign-grs.com

### DIFF
--- a/lib/whois/parsers/whois.verisign-grs.com.rb
+++ b/lib/whois/parsers/whois.verisign-grs.com.rb
@@ -20,11 +20,6 @@ module Whois
     #
     class WhoisVerisignGrsCom < BaseVerisign
 
-      property_supported :expires_on do
-        node("Expiration Date") { |value| parse_time(value) }
-      end
-
-
       property_supported :registrar do
         node("Registrar") do |value|
           Parser::Registrar.new(

--- a/spec/fixtures/responses/whois.verisign-grs.com/com/status_registered.txt
+++ b/spec/fixtures/responses/whois.verisign-grs.com/com/status_registered.txt
@@ -266,7 +266,7 @@ for detailed information.
    Status: serverUpdateProhibited
    Updated Date: 20-jul-2011
    Creation Date: 15-sep-1997
-   Expiration Date: 14-sep-2020
+   Registry Expiry Date: 14-sep-2020
 
 >>> Last update of whois database: Tue, 18 Mar 2014 13:37:06 UTC <<<
 

--- a/spec/fixtures/responses/whois.verisign-grs.com/net/status_registered.txt
+++ b/spec/fixtures/responses/whois.verisign-grs.com/net/status_registered.txt
@@ -21,7 +21,7 @@ for detailed information.
    Status: serverUpdateProhibited
    Updated Date: 11-feb-2014
    Creation Date: 15-mar-1999
-   Expiration Date: 15-mar-2015
+   Registry Expiry Date: 15-mar-2015
 
 >>> Last update of whois database: Tue, 18 Mar 2014 13:37:06 UTC <<<
 


### PR DESCRIPTION
The return from the server `whois.verisign-grs.com` has changed, and no longer has the `Expiration Date` node. This has now been renamed to `Registry Expiry Date`, as the other servers.

Here is an example request:

```
irb(main):001:0> whois = Whois::Client.new
=> #<Whois::Client:0x005632780269e8 @timeout=10, @settings={}>
irb(main):002:0> whois.lookup('mateus.net')
=> "   Domain Name: MATEUS.NET\r\n   Registry Domain ID: 5607265_DOMAIN_NET-VRSN\r\n   Registrar WHOIS Server: whois.wildwestdomains.com\r\n   Registrar URL: http://www.wildwestdomains.com\r\n   Updated Date: 2017-01-26T21:51:05Z\r\n   Creation Date: 1999-02-15T05:00:00Z\r\n   Registry Expiry Date: 2018-02-15T05:00:00Z\r\n   Registrar: Wild West Domains, LLC\r\n   Registrar IANA ID: 440\r\n   Registrar Abuse Contact Email: abuse@wildwestdomains.com\r\n   Registrar Abuse Contact Phone: 480-624-2505\r\n   Domain Status: clientDeleteProhibited https://icann.org/epp#clientDeleteProhibited\r\n   Domain Status: clientRenewProhibited https://icann.org/epp#clientRenewProhibited\r\n   Domain Status: clientTransferProhibited https://icann.org/epp#clientTransferProhibited\r\n   Domain Status: clientUpdateProhibited https://icann.org/epp#clientUpdateProhibited\r\n   Name Server: NS1.GRANITECANYON.COM\r\n   Name Server: NS2.GRANITECANYON.COM\r\n   DNSSEC: unsigned\r\n   URL of the ICANN Whois Inaccuracy Complaint Form: https://www.icann.org/wicf/\r\n>>> Last update of whois database: 2017-07-31T14:16:55Z <<<\r\n\r\nFor more information on Whois status codes, please visit https://icann.org/epp\r\n\r\nNOTICE: The expiration date displayed in this record is the date the\r\nregistrar's sponsorship of the domain name registration in the registry is\r\ncurrently set to expire. This date does not necessarily reflect the expiration\r\ndate of the domain name registrant's agreement with the sponsoring\r\nregistrar.  Users may consult the sponsoring registrar's Whois database to\r\nview the registrar's reported date of expiration for this registration.\r\n\r\nTERMS OF USE: You are not authorized to access or query our Whois\r\ndatabase through the use of electronic processes that are high-volume and\r\nautomated except as reasonably necessary to register domain names or\r\nmodify existing registrations; the Data in VeriSign Global Registry\r\nServices' (\"VeriSign\") Whois database is provided by VeriSign for\r\ninformation purposes only, and to assist persons in obtaining information\r\nabout or related to a domain name registration record. VeriSign does not\r\nguarantee its accuracy. By submitting a Whois query, you agree to abide\r\nby the following terms of use: You agree that you may use this Data only\r\nfor lawful purposes and that under no circumstances will you use this Data\r\nto: (1) allow, enable, or otherwise support the transmission of mass\r\nunsolicited, commercial advertising or solicitations via e-mail, telephone,\r\nor facsimile; or (2) enable high volume, automated, electronic processes\r\nthat apply to VeriSign (or its computer systems). The compilation,\r\nrepackaging, dissemination or other use of this Data is expressly\r\nprohibited without the prior written consent of VeriSign. You agree not to\r\nuse electronic processes that are automated and high-volume to access or\r\nquery the Whois database except as reasonably necessary to register\r\ndomain names or modify existing registrations. VeriSign reserves the right\r\nto restrict your access to the Whois database in its sole discretion to ensure\r\noperational stability.  VeriSign may restrict or terminate your access to the\r\nWhois database for failure to abide by these terms of use. VeriSign\r\nreserves the right to modify these terms at any time.\r\n\r\nThe Registry database contains ONLY .COM, .NET, .EDU domains and\r\nRegistrars.\r\n\nDomain Name: MATEUS.NET\r\nRegistry Domain ID: 5607265_DOMAIN_NET-VRSN\r\nRegistrar WHOIS Server: whois.wildwestdomains.com\r\nRegistrar URL: http://www.wildwestdomains.com\r\nUpdate Date: 2017-01-26T21:51:03Z\r\nCreation Date: 1999-02-15T05:00:00Z\r\nRegistrar Registration Expiration Date: 2018-02-15T05:00:00Z\r\nRegistrar: Wild West Domains, LLC\r\nRegistrar IANA ID: 440\r\nRegistrar Abuse Contact Email: abuse@wildwestdomains.com\r\nRegistrar Abuse Contact Phone: +1.4806242505\r\nReseller: REGISTRATION SOLUTIONS\r\nDomain Status: clientTransferProhibited http://www.icann.org/epp#clientTransferProhibited\r\nDomain Status: clientUpdateProhibited http://www.icann.org/epp#clientUpdateProhibited\r\nDomain Status: clientRenewProhibited http://www.icann.org/epp#clientRenewProhibited\r\nDomain Status: clientDeleteProhibited http://www.icann.org/epp#clientDeleteProhibited\r\nRegistry Registrant ID: Not Available From Registry\r\nRegistrant Name: E.E. Layne\r\nRegistrant Organization: The Polygenix Group Co.\r\nRegistrant Street: c/o 4025 Dorchester Road\r\nRegistrant Street: Suite 148\r\nRegistrant City: Niagara Falls\r\nRegistrant State/Province: Ontario\r\nRegistrant Postal Code: L2E 7K8\r\nRegistrant Country: CA\r\nRegistrant Phone: 9053250166\r\nRegistrant Phone Ext: \r\nRegistrant Fax: \r\nRegistrant Fax Ext: \r\nRegistrant Email: polygenix@registrationsolutions.com\r\nRegistry Admin ID: Not Available From Registry\r\nAdmin Name: Richard daCosta\r\nAdmin Organization: thedotpeople.com\r\nAdmin Street: 4025 Dorchester Road\r\nAdmin Street: Suite 148\r\nAdmin City: Niagara Falls\r\nAdmin State/Province: Ontario\r\nAdmin Postal Code: L2E 7K8\r\nAdmin Country: CA\r\nAdmin Phone: 9053250166\r\nAdmin Phone Ext: \r\nAdmin Fax: 6474390791\r\nAdmin Fax Ext: \r\nAdmin Email: admin@thedotpeople.com\r\nRegistry Tech ID: Not Available From Registry\r\nTech Name: Richard daCosta\r\nTech Organization: thedotpeople.com\r\nTech Street: 4025 Dorchester Road\r\nTech Street: Suite 148\r\nTech City: Niagara Falls\r\nTech State/Province: Ontario\r\nTech Postal Code: L2E 7K8\r\nTech Country: CA\r\nTech Phone: 9053250166\r\nTech Phone Ext: \r\nTech Fax: 6474390791\r\nTech Fax Ext: \r\nTech Email: admin@thedotpeople.com\r\nName Server: NS1.GRANITECANYON.COM\r\nName Server: NS2.GRANITECANYON.COM\r\nDNSSEC: unsigned\r\nURL of the ICANN WHOIS Data Problem Reporting System: http://wdprs.internic.net/\r\n>>> Last update of WHOIS database: 2017-07-31T14:00:00Z <<<\r\n\r\nFor more information on Whois status codes, please visit https://www.icann.org/resources/pages/epp-status-codes-2014-06-16-en\r\n\r\nThe data contained in this Registrar's Whois database, \r\nwhile believed by the registrar to be reliable, is provided \"as is\"\r\nwith no guarantee or warranties regarding its accuracy. This information \r\nis provided for the sole purpose of assisting you in obtaining \r\ninformation about domain name registration records. Any use of\r\nthis data for any other purpose is expressly forbidden without\r\nthe prior written permission of this registrar.  By submitting an\r\ninquiry, you agree to these terms of usage and limitations of warranty.\r\nIn particular, you agree not to use this data to allow, enable, or\r\notherwise make possible, dissemination or collection of this data, in \r\npart or in its entirety, for any purpose, such as the transmission of \r\nunsolicited advertising and solicitations of any kind, including spam. \r\nYou further agree not to use this data to enable high volume, automated \r\nor robotic electronic processes designed to collect or compile this data \r\nfor any purpose, including mining this data for your own personal or \r\ncommercial purposes.\r\n\r\nPlease note: the owner of the domain name is specified in the \"registrant\" section. \r\nIn most cases, the Registrar is not the owner of domain names listed in this database.\r\n"
```

Because of that, the patch method for `#expires_on` is no longer needed for this server.