### PR TITLE
Switching whois.nic.co to use "Registry Expiry Date"

### DIFF
--- a/lib/whois/parsers/whois.nic.co.rb
+++ b/lib/whois/parsers/whois.nic.co.rb
@@ -19,6 +19,13 @@ module Whois
     #   The Example parser for the list of all available methods.
     #
     class WhoisNicCo < BaseShared2
+
+      property_supported :expires_on do
+        node("Registry Expiry Date") do |value|
+          parse_time(value)
+        end
+      end
+
     end
 
   end


### PR DESCRIPTION
I support a few .co domains, and the gem isn't currently returning expires_on for .co domains. The server whois.nic.co is now using "Registry Expiry Date", and so I added it to whois.nic.co.rb.