### PR TITLE
Fix domain_id, registrar and contact parsing for afilias

### DIFF
--- a/lib/whois/parsers/whois.afilias.net.rb
+++ b/lib/whois/parsers/whois.afilias.net.rb
@@ -35,6 +35,47 @@ module Whois
         !!node("status:reserved")
       end
 
+      property_supported :domain_id do
+        node("Registry Domain ID")
+      end
+
+      property_supported :registrar do
+        node("Registrar") do |value|
+          Parser::Registrar.new(
+              id:   node("Registrar IANA ID"),
+              name: node("Registrar"),
+              organization: node("Registrar"),
+              url:  node("Registrar URL")
+          )
+        end
+      end
+
+      private
+
+      def build_contact(element, type)
+        node("Registry #{element} ID") do
+          address = ["", "1", "2", "3"].
+              map { |i| node("#{element} Street#{i}") }.
+              delete_if { |i| i.nil? || i.empty? }.
+              join("\n")
+
+          Parser::Contact.new(
+              :type         => type,
+              :id           => node("Registry #{element} ID"),
+              :name         => node("#{element} Name"),
+              :organization => node("#{element} Organization"),
+              :address      => address,
+              :city         => node("#{element} City"),
+              :zip          => node("#{element} Postal Code"),
+              :state        => node("#{element} State/Province"),
+              :country_code => node("#{element} Country"),
+              :phone        => node("#{element} Phone"),
+              :fax          => node("#{element} FAX") || node("#{element} Fax"),
+              :email        => node("#{element} Email")
+          )
+        end
+      end
+
     end
 
   end

--- a/spec/fixtures/responses/whois.afilias.net/info/status_registered.expected
+++ b/spec/fixtures/responses/whois.afilias.net/info/status_registered.expected
@@ -10,7 +10,7 @@
 
 
 #status
-  %s == ["clientDeleteProhibited", "clientTransferProhibited", "clientUpdateProhibited"]
+  %s == ["clientDeleteProhibited https://icann.org/epp#clientDeleteProhibited", "clientTransferProhibited https://icann.org/epp#clientTransferProhibited", "clientUpdateProhibited https://icann.org/epp#clientUpdateProhibited"]
 
 #available?
   %s == false
@@ -25,26 +25,26 @@
 
 #updated_on
   %s %CLASS{time}
-  %s %TIME{2013-06-29 09:26:18 UTC}
+  %s %TIME{2017-06-29 09:35:17 UTC}
 
 #expires_on
   %s %CLASS{time}
-  %s %TIME{2014-07-31 23:57:50 UTC}
+  %s %TIME{2018-07-31 23:57:50 UTC}
 
 
 #registrar
   %s %CLASS{registrar}
-  %s.id           == "R151-LRMS"
+  %s.id           == "292"
   %s.name         == "MarkMonitor Inc."
-  %s.organization == nil
-  %s.url          == nil
+  %s.organization == "MarkMonitor Inc."
+  %s.url          == "http://www.markmonitor.com"
 
 #registrant_contacts
   %s %CLASS{array}
   %s %SIZE{1}
   %s[0] %CLASS{contact}
   %s[0].type         == Whois::Parser::Contact::TYPE_REGISTRANT
-  %s[0].id           == "mmr-32097"
+  %s[0].id           == "C60668647-LRMS"
   %s[0].name         == "DNS Admin"
   %s[0].organization == "Google Inc."
   %s[0].address      == "1600 Amphitheatre Parkway"
@@ -61,7 +61,7 @@
   %s %SIZE{1}
   %s[0] %CLASS{contact}
   %s[0].type         == Whois::Parser::Contact::TYPE_ADMINISTRATIVE
-  %s[0].id           == "mmr-32097"
+  %s[0].id           == "C60668647-LRMS"
   %s[0].name         == "DNS Admin"
   %s[0].organization == "Google Inc."
   %s[0].address      == "1600 Amphitheatre Parkway"
@@ -78,7 +78,7 @@
   %s %SIZE{1}
   %s[0] %CLASS{contact}
   %s[0].type         == Whois::Parser::Contact::TYPE_TECHNICAL
-  %s[0].id           == "mmr-32097"
+  %s[0].id           == "C60668647-LRMS"
   %s[0].name         == "DNS Admin"
   %s[0].organization == "Google Inc."
   %s[0].address      == "1600 Amphitheatre Parkway"

--- a/spec/fixtures/responses/whois.afilias.net/info/status_registered.txt
+++ b/spec/fixtures/responses/whois.afilias.net/info/status_registered.txt
@@ -1,86 +1,79 @@
-Domain Name:GOOGLE.INFO
-Domain ID: D37288-LRMS
+Domain Name: GOOGLE.INFO
+Registry Domain ID: D37288-LRMS
+Registrar WHOIS Server: whois.markmonitor.com
+Registrar URL: http://www.markmonitor.com
+Updated Date: 2017-06-29T09:35:17Z
 Creation Date: 2001-07-31T23:57:50Z
-Updated Date: 2013-06-29T09:26:18Z
-Registry Expiry Date: 2014-07-31T23:57:50Z
-Trademark Name:GOOGLE
-Trademark Date:1999-09-17
-Trademark Country:Mexico
-Trademark Number:622722
-Sponsoring Registrar:MarkMonitor Inc. (R151-LRMS)
-Sponsoring Registrar IANA ID: 292
-WHOIS Server: 
-Referral URL: 
-Domain Status: clientDeleteProhibited
-Domain Status: clientTransferProhibited
-Domain Status: clientUpdateProhibited
-Registrant ID:mmr-32097
-Registrant Name:DNS Admin
-Registrant Organization:Google Inc.
+Registry Expiry Date: 2018-07-31T23:57:50Z
+Registrar Registration Expiration Date:
+Registrar: MarkMonitor Inc.
+Registrar IANA ID: 292
+Registrar Abuse Contact Email: abusecomplaints@markmonitor.com
+Registrar Abuse Contact Phone: +1.2083895740
+Reseller:
+Domain Status: clientDeleteProhibited https://icann.org/epp#clientDeleteProhibited
+Domain Status: clientTransferProhibited https://icann.org/epp#clientTransferProhibited
+Domain Status: clientUpdateProhibited https://icann.org/epp#clientUpdateProhibited
+Registry Registrant ID: C60668647-LRMS
+Registrant Name: DNS Admin
+Registrant Organization: Google Inc.
 Registrant Street: 1600 Amphitheatre Parkway
-Registrant City:Mountain View
-Registrant State/Province:CA
-Registrant Postal Code:94043
-Registrant Country:US
-Registrant Phone:+1.6506234000
-Registrant Phone Ext: 
+Registrant City: Mountain View
+Registrant State/Province: CA
+Registrant Postal Code: 94043
+Registrant Country: US
+Registrant Phone: +1.6506234000
+Registrant Phone Ext:
 Registrant Fax: +1.6506188571
-Registrant Fax Ext: 
-Registrant Email:dns-admin@google.com
-Admin ID:mmr-32097
-Admin Name:DNS Admin
-Admin Organization:Google Inc.
+Registrant Fax Ext:
+Registrant Email: dns-admin@google.com
+Registry Admin ID: C60668647-LRMS
+Admin Name: DNS Admin
+Admin Organization: Google Inc.
 Admin Street: 1600 Amphitheatre Parkway
-Admin City:Mountain View
-Admin State/Province:CA
-Admin Postal Code:94043
-Admin Country:US
-Admin Phone:+1.6506234000
-Admin Phone Ext: 
+Admin City: Mountain View
+Admin State/Province: CA
+Admin Postal Code: 94043
+Admin Country: US
+Admin Phone: +1.6506234000
+Admin Phone Ext:
 Admin Fax: +1.6506188571
-Admin Fax Ext: 
-Admin Email:dns-admin@google.com
-Billing ID:mmr-32097
-Billing Name:DNS Admin
-Billing Organization:Google Inc.
-Billing Street: 1600 Amphitheatre Parkway
-Billing City:Mountain View
-Billing State/Province:CA
-Billing Postal Code:94043
-Billing Country:US
-Billing Phone:+1.6506234000
-Billing Phone Ext: 
-Billing Fax: +1.6506188571
-Billing Fax Ext: 
-Billing Email:dns-admin@google.com
-Tech ID:mmr-32097
-Tech Name:DNS Admin
-Tech Organization:Google Inc.
+Admin Fax Ext:
+Admin Email: dns-admin@google.com
+Registry Tech ID: C60668647-LRMS
+Tech Name: DNS Admin
+Tech Organization: Google Inc.
 Tech Street: 1600 Amphitheatre Parkway
-Tech City:Mountain View
-Tech State/Province:CA
-Tech Postal Code:94043
-Tech Country:US
-Tech Phone:+1.6506234000
-Tech Phone Ext: 
+Tech City: Mountain View
+Tech State/Province: CA
+Tech Postal Code: 94043
+Tech Country: US
+Tech Phone: +1.6506234000
+Tech Phone Ext:
 Tech Fax: +1.6506188571
-Tech Fax Ext: 
-Tech Email:dns-admin@google.com
-Name Server:NS1.GOOGLE.COM
-Name Server:NS2.GOOGLE.COM
-Name Server:NS3.GOOGLE.COM
-Name Server:NS4.GOOGLE.COM
-Name Server: 
-Name Server: 
-Name Server: 
-Name Server: 
-Name Server: 
-Name Server: 
-Name Server: 
-Name Server: 
-Name Server: 
-DNSSEC:Unsigned
+Tech Fax Ext:
+Tech Email: dns-admin@google.com
+Registry Billing ID: C60668647-LRMS
+Billing Name: DNS Admin
+Billing Organization: Google Inc.
+Billing Street: 1600 Amphitheatre Parkway
+Billing City: Mountain View
+Billing State/Province: CA
+Billing Postal Code: 94043
+Billing Country: US
+Billing Phone: +1.6506234000
+Billing Phone Ext:
+Billing Fax: +1.6506188571
+Billing Fax Ext:
+Billing Email: dns-admin@google.com
+Name Server: NS1.GOOGLE.COM
+Name Server: NS2.GOOGLE.COM
+Name Server: NS3.GOOGLE.COM
+Name Server: NS4.GOOGLE.COM
+DNSSEC: unsigned
+URL of the ICANN Whois Inaccuracy Complaint Form: https://www.icann.org/wicf/
+>>> Last update of WHOIS database: 2018-05-04T12:34:05Z <<<
+
+For more information on Whois status codes, please visit https://icann.org/epp
 
 Access to AFILIAS WHOIS information is provided to assist persons in determining the contents of a domain name registration record in the Afilias registry database. The data in this record is provided by Afilias Limited for informational purposes only, and Afilias does not guarantee its accuracy.  This service is intended only for query-based access. You agree that you will use this data only for lawful purposes and that, under no circumstances will you use this data to(a) allow, enable, or otherwise support the transmission by e-mail, telephone, or facsimile of mass unsolicited, commercial advertising or solicitations to entities other than the data recipient's own existing customers; or (b) enable high volume, automated, electronic processes that send queries or data to the systems of Registry Operator, a Registrar, or Afilias except as reasonably necessary to register domain names or modify existing registrations. All rights reserved. Afilias reserves the right to modify these terms at any time. By submitting this query, you agree to abide by this policy.
-
-

--- a/spec/fixtures/responses/whois.afilias.net/pro/status_registered.expected
+++ b/spec/fixtures/responses/whois.afilias.net/pro/status_registered.expected
@@ -25,26 +25,26 @@
 
 #updated_on
   %s %CLASS{time}
-  %s %TIME{2016-02-01 15:44:03 UTC}
+  %s %TIME{2017-08-07 09:24:28 UTC}
 
 #expires_on
   %s %CLASS{time}
-  %s %TIME{2016-09-08 00:00:00 UTC}
+  %s %TIME{2018-09-08 00:00:00 UTC}
 
 
 #registrar
   %s %CLASS{registrar}
-  %s.id           == nil
+  %s.id           == "292"
   %s.name         == "MarkMonitor Inc."
-  %s.organization == nil
-  %s.url          == nil
+  %s.organization == "MarkMonitor Inc."
+  %s.url          == "http://www.markmonitor.com"
 
 #registrant_contacts
   %s %CLASS{array}
   %s %SIZE{1}
   %s[0] %CLASS{contact}
   %s[0].type          == Whois::Parser::Contact::TYPE_REGISTRANT
-  %s[0].id            == "mmr-2383"
+  %s[0].id            == "C51599151-LRMS"
   %s[0].name          == "DNS Admin"
   %s[0].organization  == "Google Inc."
   %s[0].address       == "1600 Amphitheatre Parkway"
@@ -61,7 +61,7 @@
   %s %SIZE{1}
   %s[0] %CLASS{contact}
   %s[0].type          == Whois::Parser::Contact::TYPE_ADMINISTRATIVE
-  %s[0].id            == "mmr-2383"
+  %s[0].id            == "C51599151-LRMS"
   %s[0].name          == "DNS Admin"
   %s[0].organization  == "Google Inc."
   %s[0].address       == "1600 Amphitheatre Parkway"
@@ -78,7 +78,7 @@
   %s %SIZE{1}
   %s[0] %CLASS{contact}
   %s[0].type          == Whois::Parser::Contact::TYPE_TECHNICAL
-  %s[0].id            == "mmr-2383"
+  %s[0].id            == "C51599151-LRMS"
   %s[0].name          == "DNS Admin"
   %s[0].organization  == "Google Inc."
   %s[0].address       == "1600 Amphitheatre Parkway"

--- a/spec/fixtures/responses/whois.afilias.net/pro/status_registered.txt
+++ b/spec/fixtures/responses/whois.afilias.net/pro/status_registered.txt
@@ -1,16 +1,20 @@
 Domain Name: GOOGLE.PRO
-Domain ID: D107300000000011545-LRMS
-WHOIS Server:
-Referral URL: http://www.markmonitor.com
-Updated Date: 2016-02-01T15:44:03Z
+Registry Domain ID: D107300000000011545-LRMS
+Registrar WHOIS Server: whois.markmonitor.com
+Registrar URL: http://www.markmonitor.com
+Updated Date: 2017-08-07T09:24:28Z
 Creation Date: 2008-07-22T00:00:00Z
-Registry Expiry Date: 2016-09-08T00:00:00Z
-Sponsoring Registrar: MarkMonitor Inc.
-Sponsoring Registrar IANA ID: 292
+Registry Expiry Date: 2018-09-08T00:00:00Z
+Registrar Registration Expiration Date:
+Registrar: MarkMonitor Inc.
+Registrar IANA ID: 292
+Registrar Abuse Contact Email: abusecomplaints@markmonitor.com
+Registrar Abuse Contact Phone: +1.2083895740
+Reseller:
 Domain Status: clientDeleteProhibited https://icann.org/epp#clientDeleteProhibited
 Domain Status: clientTransferProhibited https://icann.org/epp#clientTransferProhibited
 Domain Status: clientUpdateProhibited https://icann.org/epp#clientUpdateProhibited
-Registrant ID: mmr-2383
+Registry Registrant ID: C51599151-LRMS
 Registrant Name: DNS Admin
 Registrant Organization: Google Inc.
 Registrant Street: 1600 Amphitheatre Parkway
@@ -23,7 +27,7 @@ Registrant Phone Ext:
 Registrant Fax: +1.6506188571
 Registrant Fax Ext:
 Registrant Email: dns-admin@google.com
-Admin ID: mmr-2383
+Registry Admin ID: C51599151-LRMS
 Admin Name: DNS Admin
 Admin Organization: Google Inc.
 Admin Street: 1600 Amphitheatre Parkway
@@ -36,7 +40,7 @@ Admin Phone Ext:
 Admin Fax: +1.6506188571
 Admin Fax Ext:
 Admin Email: dns-admin@google.com
-Tech ID: mmr-2383
+Registry Tech ID: C51599151-LRMS
 Tech Name: DNS Admin
 Tech Organization: Google Inc.
 Tech Street: 1600 Amphitheatre Parkway
@@ -49,7 +53,7 @@ Tech Phone Ext:
 Tech Fax: +1.6506188571
 Tech Fax Ext:
 Tech Email: dns-admin@google.com
-Billing ID: mmr-132627
+Registry Billing ID: C166371517-LRMS
 Billing Name: CCOPS Billing
 Billing Organization: MarkMonitor, Inc.
 Billing Street: 391 N. Ancestor Place
@@ -65,8 +69,9 @@ Billing Email: ccopsbilling@markmonitor.com
 Name Server: NS1.GOOGLE.COM
 Name Server: NS2.GOOGLE.COM
 DNSSEC: unsigned
->>> Last update of WHOIS database: 2016-02-19T15:43:18Z <<<
+URL of the ICANN Whois Inaccuracy Complaint Form: https://www.icann.org/wicf/
+>>> Last update of WHOIS database: 2018-05-04T12:52:18Z <<<
 
-"For more information on Whois status codes, please visit https://icann.org/epp"
+For more information on Whois status codes, please visit https://icann.org/epp
 
 Access to AFILIAS WHOIS information is provided to assist persons in determining the contents of a domain name registration record in the Afilias registry database. The data in this record is provided by Afilias Limited for informational purposes only, and Afilias does not guarantee its accuracy.  This service is intended only for query-based access. You agree that you will use this data only for lawful purposes and that, under no circumstances will you use this data to(a) allow, enable, or otherwise support the transmission by e-mail, telephone, or facsimile of mass unsolicited, commercial advertising or solicitations to entities other than the data recipient's own existing customers; or (b) enable high volume, automated, electronic processes that send queries or data to the systems of Registry Operator, a Registrar, or Afilias except as reasonably necessary to register domain names or modify existing registrations. All rights reserved. Afilias reserves the right to modify these terms at any time. By submitting this query, you agree to abide by this policy.

--- a/spec/whois/parsers/responses/whois.afilias.net/info/status_registered_spec.rb
+++ b/spec/whois/parsers/responses/whois.afilias.net/info/status_registered_spec.rb
@@ -38,7 +38,7 @@ describe Whois::Parsers::WhoisAfiliasNet, "status_registered.expected" do
   end
   describe "#status" do
     it do
-      expect(subject.status).to eq(["clientDeleteProhibited", "clientTransferProhibited", "clientUpdateProhibited"])
+      expect(subject.status).to eq(["clientDeleteProhibited https://icann.org/epp#clientDeleteProhibited", "clientTransferProhibited https://icann.org/epp#clientTransferProhibited", "clientUpdateProhibited https://icann.org/epp#clientUpdateProhibited"])
     end
   end
   describe "#available?" do
@@ -60,22 +60,22 @@ describe Whois::Parsers::WhoisAfiliasNet, "status_registered.expected" do
   describe "#updated_on" do
     it do
       expect(subject.updated_on).to be_a(Time)
-      expect(subject.updated_on).to eq(Time.parse("2013-06-29 09:26:18 UTC"))
+      expect(subject.updated_on).to eq(Time.parse("2017-06-29 09:35:17 UTC"))
     end
   end
   describe "#expires_on" do
     it do
       expect(subject.expires_on).to be_a(Time)
-      expect(subject.expires_on).to eq(Time.parse("2014-07-31 23:57:50 UTC"))
+      expect(subject.expires_on).to eq(Time.parse("2018-07-31 23:57:50 UTC"))
     end
   end
   describe "#registrar" do
     it do
       expect(subject.registrar).to be_a(Whois::Parser::Registrar)
-      expect(subject.registrar.id).to eq("R151-LRMS")
+      expect(subject.registrar.id).to eq("292")
       expect(subject.registrar.name).to eq("MarkMonitor Inc.")
-      expect(subject.registrar.organization).to eq(nil)
-      expect(subject.registrar.url).to eq(nil)
+      expect(subject.registrar.organization).to eq("MarkMonitor Inc.")
+      expect(subject.registrar.url).to eq("http://www.markmonitor.com")
     end
   end
   describe "#registrant_contacts" do
@@ -84,7 +84,7 @@ describe Whois::Parsers::WhoisAfiliasNet, "status_registered.expected" do
       expect(subject.registrant_contacts.size).to eq(1)
       expect(subject.registrant_contacts[0]).to be_a(Whois::Parser::Contact)
       expect(subject.registrant_contacts[0].type).to eq(Whois::Parser::Contact::TYPE_REGISTRANT)
-      expect(subject.registrant_contacts[0].id).to eq("mmr-32097")
+      expect(subject.registrant_contacts[0].id).to eq("C60668647-LRMS")
       expect(subject.registrant_contacts[0].name).to eq("DNS Admin")
       expect(subject.registrant_contacts[0].organization).to eq("Google Inc.")
       expect(subject.registrant_contacts[0].address).to eq("1600 Amphitheatre Parkway")
@@ -103,7 +103,7 @@ describe Whois::Parsers::WhoisAfiliasNet, "status_registered.expected" do
       expect(subject.admin_contacts.size).to eq(1)
       expect(subject.admin_contacts[0]).to be_a(Whois::Parser::Contact)
       expect(subject.admin_contacts[0].type).to eq(Whois::Parser::Contact::TYPE_ADMINISTRATIVE)
-      expect(subject.admin_contacts[0].id).to eq("mmr-32097")
+      expect(subject.admin_contacts[0].id).to eq("C60668647-LRMS")
       expect(subject.admin_contacts[0].name).to eq("DNS Admin")
       expect(subject.admin_contacts[0].organization).to eq("Google Inc.")
       expect(subject.admin_contacts[0].address).to eq("1600 Amphitheatre Parkway")
@@ -122,7 +122,7 @@ describe Whois::Parsers::WhoisAfiliasNet, "status_registered.expected" do
       expect(subject.technical_contacts.size).to eq(1)
       expect(subject.technical_contacts[0]).to be_a(Whois::Parser::Contact)
       expect(subject.technical_contacts[0].type).to eq(Whois::Parser::Contact::TYPE_TECHNICAL)
-      expect(subject.technical_contacts[0].id).to eq("mmr-32097")
+      expect(subject.technical_contacts[0].id).to eq("C60668647-LRMS")
       expect(subject.technical_contacts[0].name).to eq("DNS Admin")
       expect(subject.technical_contacts[0].organization).to eq("Google Inc.")
       expect(subject.technical_contacts[0].address).to eq("1600 Amphitheatre Parkway")

--- a/spec/whois/parsers/responses/whois.afilias.net/pro/status_registered_spec.rb
+++ b/spec/whois/parsers/responses/whois.afilias.net/pro/status_registered_spec.rb
@@ -60,22 +60,22 @@ describe Whois::Parsers::WhoisAfiliasNet, "status_registered.expected" do
   describe "#updated_on" do
     it do
       expect(subject.updated_on).to be_a(Time)
-      expect(subject.updated_on).to eq(Time.parse("2016-02-01 15:44:03 UTC"))
+      expect(subject.updated_on).to eq(Time.parse("2017-08-07 09:24:28 UTC"))
     end
   end
   describe "#expires_on" do
     it do
       expect(subject.expires_on).to be_a(Time)
-      expect(subject.expires_on).to eq(Time.parse("2016-09-08 00:00:00 UTC"))
+      expect(subject.expires_on).to eq(Time.parse("2018-09-08 00:00:00 UTC"))
     end
   end
   describe "#registrar" do
     it do
       expect(subject.registrar).to be_a(Whois::Parser::Registrar)
-      expect(subject.registrar.id).to eq(nil)
+      expect(subject.registrar.id).to eq("292")
       expect(subject.registrar.name).to eq("MarkMonitor Inc.")
-      expect(subject.registrar.organization).to eq(nil)
-      expect(subject.registrar.url).to eq(nil)
+      expect(subject.registrar.organization).to eq("MarkMonitor Inc.")
+      expect(subject.registrar.url).to eq("http://www.markmonitor.com")
     end
   end
   describe "#registrant_contacts" do
@@ -84,7 +84,7 @@ describe Whois::Parsers::WhoisAfiliasNet, "status_registered.expected" do
       expect(subject.registrant_contacts.size).to eq(1)
       expect(subject.registrant_contacts[0]).to be_a(Whois::Parser::Contact)
       expect(subject.registrant_contacts[0].type).to eq(Whois::Parser::Contact::TYPE_REGISTRANT)
-      expect(subject.registrant_contacts[0].id).to eq("mmr-2383")
+      expect(subject.registrant_contacts[0].id).to eq("C51599151-LRMS")
       expect(subject.registrant_contacts[0].name).to eq("DNS Admin")
       expect(subject.registrant_contacts[0].organization).to eq("Google Inc.")
       expect(subject.registrant_contacts[0].address).to eq("1600 Amphitheatre Parkway")
@@ -103,7 +103,7 @@ describe Whois::Parsers::WhoisAfiliasNet, "status_registered.expected" do
       expect(subject.admin_contacts.size).to eq(1)
       expect(subject.admin_contacts[0]).to be_a(Whois::Parser::Contact)
       expect(subject.admin_contacts[0].type).to eq(Whois::Parser::Contact::TYPE_ADMINISTRATIVE)
-      expect(subject.admin_contacts[0].id).to eq("mmr-2383")
+      expect(subject.admin_contacts[0].id).to eq("C51599151-LRMS")
       expect(subject.admin_contacts[0].name).to eq("DNS Admin")
       expect(subject.admin_contacts[0].organization).to eq("Google Inc.")
       expect(subject.admin_contacts[0].address).to eq("1600 Amphitheatre Parkway")
@@ -122,7 +122,7 @@ describe Whois::Parsers::WhoisAfiliasNet, "status_registered.expected" do
       expect(subject.technical_contacts.size).to eq(1)
       expect(subject.technical_contacts[0]).to be_a(Whois::Parser::Contact)
       expect(subject.technical_contacts[0].type).to eq(Whois::Parser::Contact::TYPE_TECHNICAL)
-      expect(subject.technical_contacts[0].id).to eq("mmr-2383")
+      expect(subject.technical_contacts[0].id).to eq("C51599151-LRMS")
       expect(subject.technical_contacts[0].name).to eq("DNS Admin")
       expect(subject.technical_contacts[0].organization).to eq("Google Inc.")
       expect(subject.technical_contacts[0].address).to eq("1600 Amphitheatre Parkway")


### PR DESCRIPTION
Afilias has changed there whois format in accordance with ICANNs requirements. This is a try at updating to parse the new format.