### PR TITLE
Update nic.io for created, expires and updated values

### DIFF
--- a/lib/whois/parsers/whois.nic.io.rb
+++ b/lib/whois/parsers/whois.nic.io.rb
@@ -36,6 +36,26 @@ module Whois
         end
       end
 
+      property_supported :created_on do
+        if content_for_scanner =~ /Creation Date:\s+(.+)\n/
+          y, m, d = $1.split("-")
+          parse_time("#{y}-#{m}-#{d}")
+        end
+      end
+
+      property_supported :updated_on do
+        if content_for_scanner =~ /Updated Date:\s+(.+)\n/
+          y, m, d = $1.split("-")
+          parse_time("#{y}-#{m}-#{d}")
+        end
+      end
+
+      property_supported :expires_on do
+        if content_for_scanner =~ /Registry Expiry Date:\s+(.+)\n/
+          y, m, d = $1.split("-")
+          parse_time("#{y}-#{m}-#{d}")
+        end
+      end
 
       # NEWPROPERTY
       def reserved?

--- a/spec/fixtures/responses/whois.nic.io/io/status_registered.txt
+++ b/spec/fixtures/responses/whois.nic.io/io/status_registered.txt
@@ -1,7 +1,6 @@
 
 Domain : redis.io
 Status : Live
-Expiry : 2014-05-28
 
 NS 1   : ns1.iwantmyname.net
 NS 2   : ns2.iwantmyname.net
@@ -15,3 +14,6 @@ Owner  : Campobello di Licata (AG
 Owner  : .
 Owner  : IT
 
+Creation Date: 2010-05-28
+Updated Date: 2018-04-13
+Registry Expiry Date: 2019-05-28

--- a/spec/whois/parsers/responses/whois.nic.io/io/status_available_spec.rb
+++ b/spec/whois/parsers/responses/whois.nic.io/io/status_available_spec.rb
@@ -53,12 +53,12 @@ describe Whois::Parsers::WhoisNicIo, "status_available.expected" do
   end
   describe "#created_on" do
     it do
-      expect { subject.created_on }.to raise_error(Whois::AttributeNotSupported)
+      expect(subject.created_on).to eq(nil)
     end
   end
   describe "#updated_on" do
     it do
-      expect { subject.updated_on }.to raise_error(Whois::AttributeNotSupported)
+      expect(subject.updated_on).to eq(nil)
     end
   end
   describe "#expires_on" do

--- a/spec/whois/parsers/responses/whois.nic.io/io/status_registered_spec.rb
+++ b/spec/whois/parsers/responses/whois.nic.io/io/status_registered_spec.rb
@@ -53,18 +53,20 @@ describe Whois::Parsers::WhoisNicIo, "status_registered.expected" do
   end
   describe "#created_on" do
     it do
-      expect { subject.created_on }.to raise_error(Whois::AttributeNotSupported)
+      expect(subject.created_on).to be_a(Time)
+      expect(subject.created_on).to eq(Time.parse("2010-05-28"))
     end
   end
   describe "#updated_on" do
     it do
-      expect { subject.updated_on }.to raise_error(Whois::AttributeNotSupported)
+      expect(subject.updated_on).to be_a(Time)
+      expect(subject.updated_on).to eq(Time.parse("2018-04-13"))
     end
   end
   describe "#expires_on" do
     it do
       expect(subject.expires_on).to be_a(Time)
-      expect(subject.expires_on).to eq(Time.parse("2014-05-28"))
+      expect(subject.expires_on).to eq(Time.parse("2019-05-28"))
     end
   end
   describe "#registrar" do

--- a/spec/whois/parsers/responses/whois.nic.io/io/status_reserved_spec.rb
+++ b/spec/whois/parsers/responses/whois.nic.io/io/status_reserved_spec.rb
@@ -53,12 +53,12 @@ describe Whois::Parsers::WhoisNicIo, "status_reserved.expected" do
   end
   describe "#created_on" do
     it do
-      expect { subject.created_on }.to raise_error(Whois::AttributeNotSupported)
+      expect(subject.created_on).to eq(nil)
     end
   end
   describe "#updated_on" do
     it do
-      expect { subject.updated_on }.to raise_error(Whois::AttributeNotSupported)
+      expect(subject.updated_on).to eq(nil)
     end
   end
   describe "#expires_on" do


### PR DESCRIPTION
I wanted to get the created, expires and updated values from a .io domain using this gem but noticed that the expires value was outdated and created and updated values not supported. So I quickly updated the expires and added the created and updated values. The rspec unit tests are all good (6319 examples, 0 failures).