### PR TITLE
Update domreg.lt parser

### DIFF
--- a/lib/whois/parsers/whois.domreg.lt.rb
+++ b/lib/whois/parsers/whois.domreg.lt.rb
@@ -49,8 +49,11 @@ module Whois
 
       property_not_supported :updated_on
 
-      property_not_supported :expires_on
-
+      property_supported :expires_on do
+        if content_for_scanner =~ /Expires:\s(.+)$/
+          parse_time($1)
+        end
+      end
 
       property_supported :nameservers do
         content_for_scanner.scan(/Nameserver:\s+(.+)\n/).flatten.map do |line|

--- a/spec/whois/parsers/responses/whois.domreg.lt/lt/status_available_spec.rb
+++ b/spec/whois/parsers/responses/whois.domreg.lt/lt/status_available_spec.rb
@@ -48,7 +48,7 @@ describe Whois::Parsers::WhoisDomregLt, "status_available.expected" do
   end
   describe "#expires_on" do
     it do
-      expect { subject.expires_on }.to raise_error(Whois::AttributeNotSupported)
+      expect(subject.expires_on).to eq(nil)
     end
   end
   describe "#nameservers" do

--- a/spec/whois/parsers/responses/whois.domreg.lt/lt/status_registered_spec.rb
+++ b/spec/whois/parsers/responses/whois.domreg.lt/lt/status_registered_spec.rb
@@ -49,7 +49,7 @@ describe Whois::Parsers::WhoisDomregLt, "status_registered.expected" do
   end
   describe "#expires_on" do
     it do
-      expect { subject.expires_on }.to raise_error(Whois::AttributeNotSupported)
+      expect(subject.expires_on).to eq(nil)
     end
   end
   describe "#nameservers" do


### PR DESCRIPTION
Hello,
domreg.lt currently supports `Expires` paramater.
This patch adds ability to use it:

```
whois = Whois.whois('ring.lt')
=> "% Hello, this is the DOMREG whois service.\n%\n% By submitting a query you agree not to use the information made\n% available to:\n% - allow, enable or otherwise support the transmission of unsolicited,\n%   commercial advertising or other solicitations whether via email or\n%   otherwise;\n% - target advertising in any possible way;\n% - to cause nuisance in any possible way to the registrants by sending\n%   (whether by automated, electronic processes capable of enabling\n%   high volumes or other possible means) messages to them.\n%\n% Version 0.3\n%\n% For more information please visit http://whois.domreg.lt\n%\nDomain:\t\t\tring.lt\nStatus:\t\t\tregistered\nRegistered:\t\t2004-02-26\nExpires:\t\t2019-02-26\n%\nRegistrar:\t\tUAB \"Interneto vizija\"\nRegistrar website:\thttp://www.iv.lt/\nRegistrar email:\thostmaster@iv.lt\n%\nContact organization:\tUAB \"Interneto vizija\"\nContact email:\t\thostmaster@iv.lt\n%\nNameserver:\t\tns1.ring.lt\t[148.251.206.204]\nNameserver:\t\tns2.ring.lt\t[88.119.145.12]\n"

irb(main):005:0> expires_on = DateTime.parse(whois.parser.expires_on.to_s)
=> #<DateTime: 2019-02-26T00:00:00+00:00 ((2458541j,0s,0n),+0s,2299161j)>

irb(main):006:0> num_days = (expires_on - DateTime.now).to_i
=> 98
```