### PR TITLE
Fix bug! declaration

### DIFF
--- a/lib/whois/parser.rb
+++ b/lib/whois/parser.rb
@@ -69,10 +69,6 @@ module Whois
           " http://github.com/weppos/whois-parser/issues"
     end
 
-    def bug!(error, message)
-      self.class.bug!(error, message)
-    end
-
     METHODS = [
       :contacts,
       :changed?, :unchanged?,

--- a/lib/whois/parser.rb
+++ b/lib/whois/parser.rb
@@ -18,7 +18,7 @@ require 'active_support/core_ext/time/calculations'
 require_relative 'parser/version'
 require_relative 'parser/errors'
 
-# These extensions add Whois::Record#parser, the Whois.registered?, and 
+# These extensions add Whois::Record#parser, the Whois.registered?, and
 # Whois.available? shortcuts.
 # These are handy convenient methods, and they are loaded by default.
 require_relative 'parser_extensions/whois'
@@ -63,10 +63,14 @@ module Whois
     #
     # @api private
     # @private
-    def bug!(error, message)
+    def self.bug!(error, message)
       raise error, message.dup          +
           " Please report the issue at" +
           " http://github.com/weppos/whois-parser/issues"
+    end
+
+    def bug!(error, message)
+      self.class.bug!(error, message)
     end
 
     METHODS = [


### PR DESCRIPTION
Some parsers raise `undefined method `bug!' for Whois::Parser:Class`.
This adds the class method while keeping the instance method for
backwards compatibility.

Signed-off-by: David Calavera <david.calavera@gmail.com>