### PR TITLE
parsers/base: make sure content always ends with an empty line

### DIFF
--- a/lib/whois/parsers/base.rb
+++ b/lib/whois/parsers/base.rb
@@ -363,7 +363,7 @@ module Whois
       protected
 
       def content_for_scanner
-        @content_for_scanner ||= content.to_s.gsub(/\r\n/, "\n")
+        @content_for_scanner ||= "#{content.to_s.gsub(/\r\n/, "\n").delete_suffix("\n")}\n"
       end
 
       def cached_properties_fetch(key)

--- a/spec/whois/parsers/base_spec.rb
+++ b/spec/whois/parsers/base_spec.rb
@@ -72,15 +72,20 @@ describe Whois::Parsers::Base do
 
   describe "#content_for_scanner" do
     it "returns the part body with line feed normalized" do
+      instance = described_class.new(Whois::Record::Part.new(:body => "This is\r\nthe response.\r\n", :host => "whois.example.test"))
+      expect(instance.send(:content_for_scanner)).to eq("This is\nthe response.\n")
+    end
+
+    it "returns the part body with line feed normalized" do
       instance = described_class.new(Whois::Record::Part.new(:body => "This is\r\nthe response.", :host => "whois.example.test"))
-      expect(instance.send(:content_for_scanner)).to eq("This is\nthe response.")
+      expect(instance.send(:content_for_scanner)).to eq("This is\nthe response.\n")
     end
 
     it "caches the result" do
       instance = described_class.new(Whois::Record::Part.new(:body => "This is\r\nthe response.", :host => "whois.example.test"))
       expect(instance.instance_eval { @content_for_scanner }).to be_nil
       instance.send(:content_for_scanner)
-      expect(instance.instance_eval { @content_for_scanner }).to eq("This is\nthe response.")
+      expect(instance.instance_eval { @content_for_scanner }).to eq("This is\nthe response.\n")
     end
   end
 


### PR DESCRIPTION
For some whois output where the content does not end with an
empty new line, the whois call was returning an 'Unexpected token:
% (c) 2019 Canadian Internet Registration Authority,
(http://www.cira.ca/)' error, for instance.

This fixes that by forcing into existence that ending new line.

Note that this is going to be followed by another PR to support the last CIRA whois output, which is currently failing.