### PR TITLE
Fix the parser for the .fi TLD (Closes: #42)

### DIFF
--- a/lib/whois/scanners/whois.fi.rb
+++ b/lib/whois/scanners/whois.fi.rb
@@ -9,11 +9,13 @@ module Whois
       self.tokenizers += [
           :skip_empty_line,
           :scan_available,
-          :scan_disclaimer,
           :scan_keyvalue,
-          :scan_reserved
+          :scan_reserved,
+          :scan_section,
+          :scan_keyvalue,
+          :skip_last_update,
+          :scan_disclaimer
       ]
-
 
       tokenizer :scan_available do
         if @input.skip(/^Domain not found/)
@@ -27,13 +29,40 @@ module Whois
         end
       end
 
-      tokenizer :scan_disclaimer do
-        if @input.match?(/^More information/)
-          @ast["field:disclaimer"] = @input.scan_until(/(.*)\n\n/).strip
+      tokenizer :scan_section do
+        if @input.scan(/^(Nameservers|DNSSEC|Holder|Registrar|Tech)\n\n/)
+          @tmp['_section'] = @input[1]
+          while scan_keyvalue
+          end
+          @tmp.delete('_section')
         end
       end
 
-    end
+      # Override scan_keyvalue to match the weird
+      # key.........: value -format
+      tokenizer :scan_keyvalue do
+        if @input.scan(/(.+?)(\.+):(.*?)(\n|\z)/)
+          key, value = @input[1].strip, @input[3].strip
+          target = @tmp['_section'] ? (@ast[@tmp['_section']] ||= {}) : @ast
 
+          if target[key].nil?
+            target[key] = value
+          else
+            target[key] = Array.wrap(target[key])
+            target[key] << value
+          end
+        end
+      end
+
+      tokenizer :skip_last_update do
+        @input.skip(/^>>> Last update.*<<<\n\n/)
+      end
+
+      tokenizer :scan_disclaimer do
+        @input.skip_until(/^(Copyright \(c\) Finnish Transport and Communications Agency Traficom)/)
+        @ast["field:disclaimer"] = @input[1]
+      end
+
+    end
   end
 end

--- a/spec/fixtures/responses/whois.fi/fi/property_status_graceperiod.expected
+++ b/spec/fixtures/responses/whois.fi/fi/property_status_graceperiod.expected
@@ -1,9 +1,9 @@
 #disclaimer
-  %s == "More information is available at https://domain.fi/\nCopyright (c) Finnish Communications Regulatory Authority"
+  %s == "Copyright (c) Finnish Transport and Communications Agency Traficom"
 
 
 #domain
-  %s == "oogle.fi"
+  %s == "kalatalousministeri.fi"
 
 #domain_id
   %s %ERROR{AttributeNotSupported}
@@ -21,51 +21,69 @@
 
 #created_on
   %s %CLASS{time}
-  %s %TIME{2012-06-21}
+  %s %TIME{2018-03-14 17:47:42}
 
 #updated_on
   %s %CLASS{time}
-  %s %TIME{2013-06-22}
+  %s %TIME{2019-11-06}
 
 #expires_on
   %s %CLASS{time}
-  %s %TIME{2013-06-21}
+  %s %TIME{2020-03-14 17:47:42}
 
 
 #registrar
-  %s %ERROR{AttributeNotSupported}
+  %s.name == "Gandi SAS"
+  %s.url  == "www.gandi.net"
 
 #registrant_contacts
+  %s %ERROR{AttributeNotSupported}
+
+#admin_contacts
   %s %CLASS{array}
   %s %SIZE{1}
   %s[0] %CLASS{contact}
-  %s[0].type          == Whois::Parser::Contact::TYPE_REGISTRANT
-  %s[0].id            == "NURMI"
-  %s[0].name          == "-"
-  %s[0].organization  == "Minna"
-  %s[0].address       == "Huovitie 3"
-  %s[0].city          == "HELSINKI"
-  %s[0].zip           == "00400"
+  %s[0].type          == Whois::Parser::Contact::TYPE_ADMINISTRATIVE
+  %s[0].id            == "2823344-7"
+  %s[0].name          == "Digiteam Oy"
+  %s[0].address       == "Myllyniityntie 71"
+  %s[0].city          == "Lohja"
+  %s[0].zip           == "08100"
   %s[0].state         == nil
-  %s[0].country       == nil
+  %s[0].country       == "Finland"
   %s[0].country_code  == nil
-  %s[0].phone         == "+358201599789"
+  %s[0].phone         == "+358.503716096"
   %s[0].fax           == nil
-  %s[0].email         == nil
+  %s[0].email         == ""
   %s[0].created_on    == nil
   %s[0].updated_on    == nil
 
-#admin_contacts
-  %s %ERROR{AttributeNotSupported}
-
 #technical_contacts
-  %s %ERROR{AttributeNotSupported}
+  %s %CLASS{array}
+  %s %SIZE{1}
+  %s[0] %CLASS{contact}
+  %s[0].type          == Whois::Parser::Contact::TYPE_TECHNICAL
+  %s[0].id            == nil
+  %s[0].name          == "Seravo Oy"
+  %s[0].address       == nil
+  %s[0].city          == nil
+  %s[0].zip           == nil
+  %s[0].state         == nil
+  %s[0].country       == nil
+  %s[0].country_code  == nil
+  %s[0].phone         == nil
+  %s[0].fax           == nil
+  %s[0].email         == "hostmaster@seravo.com"
+  %s[0].created_on    == nil
+  %s[0].updated_on    == nil
 
 
 #nameservers
   %s %CLASS{array}
-  %s %SIZE{2}
+  %s %SIZE{3}
   %s[0] %CLASS{nameserver}
-  %s[0].name == "a.ns.netim.net"
+  %s[0].name == "ns-184-c.gandi.net"
   %s[1] %CLASS{nameserver}
-  %s[1].name == "b.ns.netim.net"
+  %s[1].name == "ns-196-a.gandi.net"
+  %s[2] %CLASS{nameserver}
+  %s[2].name == "ns-73-b.gandi.net"

--- a/spec/fixtures/responses/whois.fi/fi/property_status_graceperiod.txt
+++ b/spec/fixtures/responses/whois.fi/fi/property_status_graceperiod.txt
@@ -1,21 +1,45 @@
-IP: UNABLE TO RESOLVE
 
-domain:   oogle.fi
-descr:    Minna
-descr:    NURMI
-address:  -
-address:  Huovitie 3
-address:  00400
-address:  HELSINKI
-phone:    +358201599789
-status:   Grace Period
-created:  21.6.2012
-modified: 22.6.2013
-expires:  21.6.2013
-nserver:  a.ns.netim.net [Ok]
-nserver:  b.ns.netim.net [Ok]
-dnssec:   no
+domain.............: kalatalousministeri.fi
+status.............: Grace Period
+created............: 14.3.2018 17:47:42
+expires............: 14.3.2020 17:47:42
+available..........: 14.4.2020 17:47:42
+modified...........: 6.11.2019
+RegistryLock.......: no
 
-More information is available at https://domain.fi/
-Copyright (c) Finnish Communications Regulatory Authority
+Nameservers
+
+nserver............: ns-184-c.gandi.net [OK]
+nserver............: ns-196-a.gandi.net [OK]
+nserver............: ns-73-b.gandi.net [OK]
+
+DNSSEC
+
+dnssec.............: no
+
+Holder
+
+name...............: Digiteam Oy
+register number....: 2823344-7
+address............: Myllyniityntie 71
+address............: 08100
+address............: Lohja
+country............: Finland
+phone..............: +358.503716096
+holder email.......: 
+
+Registrar
+
+registrar..........: Gandi SAS
+www................: www.gandi.net
+
+Tech
+
+name...............: Seravo Oy
+email..............: hostmaster@seravo.com
+
+>>> Last update of WHOIS database: 22.3.2020 13:47:27 (EET) <<<
+
+
+Copyright (c) Finnish Transport and Communications Agency Traficom
 

--- a/spec/fixtures/responses/whois.fi/fi/status_available.expected
+++ b/spec/fixtures/responses/whois.fi/fi/status_available.expected
@@ -1,5 +1,5 @@
 #disclaimer
-  %s == "More information is available at https://domain.fi/\nCopyright (c) Finnish Communications Regulatory Authority"
+  %s == "Copyright (c) Finnish Transport and Communications Agency Traficom"
 
 
 #domain
@@ -30,17 +30,19 @@
 
 
 #registrar
-  %s %ERROR{AttributeNotSupported}
+  %s == nil
 
 #registrant_contacts
+  %s %ERROR{AttributeNotSupported}
+
+#admin_contacts
   %s %CLASS{array}
   %s == []
 
-#admin_contacts
-  %s %ERROR{AttributeNotSupported}
-
 #technical_contacts
-  %s %ERROR{AttributeNotSupported}
+  %s %CLASS{array}
+  %s == []
+
 
 
 #nameservers

--- a/spec/fixtures/responses/whois.fi/fi/status_available.txt
+++ b/spec/fixtures/responses/whois.fi/fi/status_available.txt
@@ -1,6 +1,5 @@
 
 Domain not found
 
-More information is available at https://domain.fi/
-Copyright (c) Finnish Communications Regulatory Authority
+Copyright (c) Finnish Transport and Communications Agency Traficom
 

--- a/spec/fixtures/responses/whois.fi/fi/status_registered.expected
+++ b/spec/fixtures/responses/whois.fi/fi/status_registered.expected
@@ -1,5 +1,5 @@
 #disclaimer
-  %s == "More information is available at https://domain.fi/\nCopyright (c) Finnish Communications Regulatory Authority"
+  %s == "Copyright (c) Finnish Transport and Communications Agency Traficom"
 
 
 #domain
@@ -25,51 +25,72 @@
 
 #updated_on
   %s %CLASS{time}
-  %s %TIME{2013-06-07}
+  %s %TIME{2019-06-02}
 
 #expires_on
   %s %CLASS{time}
-  %s %TIME{2014-07-04}
+  %s %TIME{2020-07-04 10:15:55}
 
 
 #registrar
-  %s %ERROR{AttributeNotSupported}
+  %s.id            == nil
+  %s.name          == "MarkMonitor Inc."
+  %s.organization  == "MarkMonitor Inc."
+  %s.url           == "www.markmonitor.com"
 
 #registrant_contacts
+  %s %ERROR{AttributeNotSupported}
+
+
+#admin_contacts
   %s %CLASS{array}
   %s %SIZE{1}
   %s[0] %CLASS{contact}
-  %s[0].type          == Whois::Parser::Contact::TYPE_REGISTRANT
-  %s[0].id            == "09073468"
-  %s[0].name          == "Domain Administrator"
-  %s[0].organization  == "Google Finland Oy"
-  %s[0].address       == "Mannerheimintie 12 B"
-  %s[0].city          == "HELSINKI"
-  %s[0].zip           == "00100"
+  %s[0].type          == Whois::Parser::Contact::TYPE_ADMINISTRATIVE
+  %s[0].id            == "3582691"
+  %s[0].name          == "Google LLC"
+  %s[0].organization  == nil
+  %s[0].address       == "1600 Amphitheatre Parkway"
+  %s[0].zip           == "94043"
+  %s[0].city          == "Mountain View"
   %s[0].state         == nil
-  %s[0].country       == nil
+  %s[0].country       == "United States of America"
   %s[0].country_code  == nil
-  %s[0].phone         == "35896966890"
+  %s[0].phone         == "+1.6502530000"
   %s[0].fax           == nil
-  %s[0].email         == nil
+  %s[0].email         == ""
   %s[0].created_on    == nil
   %s[0].updated_on    == nil
 
-#admin_contacts
-  %s %ERROR{AttributeNotSupported}
-
 #technical_contacts
-  %s %ERROR{AttributeNotSupported}
+  %s %CLASS{array}
+  %s %SIZE{1}
+  %s[0] %CLASS{contact}
+  %s[0].type          == Whois::Parser::Contact::TYPE_TECHNICAL
+  %s[0].id            == nil
+  %s[0].name          == "Google LLC"
+  %s[0].organization  == nil
+  %s[0].address       == nil
+  %s[0].city          == nil
+  %s[0].zip           == nil
+  %s[0].state         == nil
+  %s[0].country       == nil
+  %s[0].country_code  == nil
+  %s[0].phone         == nil
+  %s[0].fax           == nil
+  %s[0].email         == "ccops@markmonitor.com"
+  %s[0].created_on    == nil
+  %s[0].updated_on    == nil
 
 
 #nameservers
   %s %CLASS{array}
   %s %SIZE{4}
   %s[0] %CLASS{nameserver}
-  %s[0].name == "ns1.google.com"
+  %s[0].name == "ns3.google.com"
   %s[1] %CLASS{nameserver}
-  %s[1].name == "ns2.google.com"
+  %s[1].name == "ns4.google.com"
   %s[2] %CLASS{nameserver}
-  %s[2].name == "ns3.google.com"
+  %s[2].name == "ns1.google.com"
   %s[3] %CLASS{nameserver}
-  %s[3].name == "ns4.google.com"
+  %s[3].name == "ns2.google.com"

--- a/spec/fixtures/responses/whois.fi/fi/status_registered.txt
+++ b/spec/fixtures/responses/whois.fi/fi/status_registered.txt
@@ -1,22 +1,47 @@
 
-domain:   google.fi
-descr:    Google Finland Oy
-descr:    09073468
-address:  Domain Administrator
-address:  Mannerheimintie 12 B
-address:  00100
-address:  HELSINKI
-phone:    35896966890
-status:   Granted
-created:  30.6.2006
-modified: 7.6.2013
-expires:  4.7.2014
-nserver:  ns1.google.com [Ok]
-nserver:  ns2.google.com [Ok]
-nserver:  ns3.google.com [Ok]
-nserver:  ns4.google.com [Ok]
-dnssec:   no
+domain.............: google.fi
+status.............: Registered
+created............: 30.6.2006 00:00:00
+expires............: 4.7.2020 10:15:55
+available..........: 4.8.2020 10:15:55
+modified...........: 2.6.2019
+holder transfer....: 20.11.2018
+RegistryLock.......: locked
 
-More information is available at https://domain.fi/
-Copyright (c) Finnish Communications Regulatory Authority
+Nameservers
+
+nserver............: ns3.google.com [OK]
+nserver............: ns4.google.com [Technical Error]
+nserver............: ns1.google.com [OK]
+nserver............: ns2.google.com [OK]
+
+DNSSEC
+
+dnssec.............: no
+
+Holder
+
+name...............: Google LLC
+register number....: 3582691
+address............: 1600 Amphitheatre Parkway
+address............: 94043
+address............: Mountain View
+country............: United States of America
+phone..............: +1.6502530000
+holder email.......: 
+
+Registrar
+
+registrar..........: MarkMonitor Inc.
+www................: www.markmonitor.com
+
+Tech
+
+name...............: Google LLC
+email..............: ccops@markmonitor.com
+
+>>> Last update of WHOIS database: 11.3.2020 19:45:14 (EET) <<<
+
+
+Copyright (c) Finnish Transport and Communications Agency Traficom
 

--- a/spec/fixtures/responses/whois.fi/fi/status_reserved.expected
+++ b/spec/fixtures/responses/whois.fi/fi/status_reserved.expected
@@ -1,5 +1,5 @@
 #disclaimer
-  %s == "More information is available at https://domain.fi/\nCopyright (c) Finnish Communications Regulatory Authority"
+  %s == "Copyright (c) Finnish Transport and Communications Agency Traficom"
 
 
 #domain
@@ -30,17 +30,18 @@
 
 
 #registrar
-  %s %ERROR{AttributeNotSupported}
+  %s == nil
 
 #registrant_contacts
+  %s %ERROR{AttributeNotSupported}
+
+#admin_contacts
   %s %CLASS{array}
   %s == []
 
-#admin_contacts
-  %s %ERROR{AttributeNotSupported}
-
 #technical_contacts
-  %s %ERROR{AttributeNotSupported}
+  %s %CLASS{array}
+  %s == []
 
 
 #nameservers

--- a/spec/fixtures/responses/whois.fi/fi/status_reserved.txt
+++ b/spec/fixtures/responses/whois.fi/fi/status_reserved.txt
@@ -1,6 +1,5 @@
 
 Domain not available
 
-More information is available at https://domain.fi/
-Copyright (c) Finnish Communications Regulatory Authority
+Copyright (c) Finnish Transport and Communications Agency Traficom
 

--- a/spec/whois/parsers/responses/whois.fi/fi/property_status_graceperiod_spec.rb
+++ b/spec/whois/parsers/responses/whois.fi/fi/property_status_graceperiod_spec.rb
@@ -23,12 +23,12 @@ describe Whois::Parsers::WhoisFi, "property_status_graceperiod.expected" do
 
   describe "#disclaimer" do
     it do
-      expect(subject.disclaimer).to eq("More information is available at https://domain.fi/\nCopyright (c) Finnish Communications Regulatory Authority")
+      expect(subject.disclaimer).to eq("Copyright (c) Finnish Transport and Communications Agency Traficom")
     end
   end
   describe "#domain" do
     it do
-      expect(subject.domain).to eq("oogle.fi")
+      expect(subject.domain).to eq("kalatalousministeri.fi")
     end
   end
   describe "#domain_id" do
@@ -54,66 +54,84 @@ describe Whois::Parsers::WhoisFi, "property_status_graceperiod.expected" do
   describe "#created_on" do
     it do
       expect(subject.created_on).to be_a(Time)
-      expect(subject.created_on).to eq(Time.parse("2012-06-21"))
+      expect(subject.created_on).to eq(Time.parse("2018-03-14 17:47:42"))
     end
   end
   describe "#updated_on" do
     it do
       expect(subject.updated_on).to be_a(Time)
-      expect(subject.updated_on).to eq(Time.parse("2013-06-22"))
+      expect(subject.updated_on).to eq(Time.parse("2019-11-06"))
     end
   end
   describe "#expires_on" do
     it do
       expect(subject.expires_on).to be_a(Time)
-      expect(subject.expires_on).to eq(Time.parse("2013-06-21"))
+      expect(subject.expires_on).to eq(Time.parse("2020-03-14 17:47:42"))
     end
   end
   describe "#registrar" do
     it do
-      expect { subject.registrar }.to raise_error(Whois::AttributeNotSupported)
+      expect(subject.registrar.name).to eq("Gandi SAS")
+      expect(subject.registrar.url).to eq("www.gandi.net")
     end
   end
   describe "#registrant_contacts" do
     it do
-      expect(subject.registrant_contacts).to be_a(Array)
-      expect(subject.registrant_contacts.size).to eq(1)
-      expect(subject.registrant_contacts[0]).to be_a(Whois::Parser::Contact)
-      expect(subject.registrant_contacts[0].type).to eq(Whois::Parser::Contact::TYPE_REGISTRANT)
-      expect(subject.registrant_contacts[0].id).to eq("NURMI")
-      expect(subject.registrant_contacts[0].name).to eq("-")
-      expect(subject.registrant_contacts[0].organization).to eq("Minna")
-      expect(subject.registrant_contacts[0].address).to eq("Huovitie 3")
-      expect(subject.registrant_contacts[0].city).to eq("HELSINKI")
-      expect(subject.registrant_contacts[0].zip).to eq("00400")
-      expect(subject.registrant_contacts[0].state).to eq(nil)
-      expect(subject.registrant_contacts[0].country).to eq(nil)
-      expect(subject.registrant_contacts[0].country_code).to eq(nil)
-      expect(subject.registrant_contacts[0].phone).to eq("+358201599789")
-      expect(subject.registrant_contacts[0].fax).to eq(nil)
-      expect(subject.registrant_contacts[0].email).to eq(nil)
-      expect(subject.registrant_contacts[0].created_on).to eq(nil)
-      expect(subject.registrant_contacts[0].updated_on).to eq(nil)
+      expect { subject.registrant_contacts }.to raise_error(Whois::AttributeNotSupported)
     end
   end
   describe "#admin_contacts" do
     it do
-      expect { subject.admin_contacts }.to raise_error(Whois::AttributeNotSupported)
+      expect(subject.admin_contacts).to be_a(Array)
+      expect(subject.admin_contacts.size).to eq(1)
+      expect(subject.admin_contacts[0]).to be_a(Whois::Parser::Contact)
+      expect(subject.admin_contacts[0].type).to eq(Whois::Parser::Contact::TYPE_ADMINISTRATIVE)
+      expect(subject.admin_contacts[0].id).to eq("2823344-7")
+      expect(subject.admin_contacts[0].name).to eq("Digiteam Oy")
+      expect(subject.admin_contacts[0].address).to eq("Myllyniityntie 71")
+      expect(subject.admin_contacts[0].city).to eq("Lohja")
+      expect(subject.admin_contacts[0].zip).to eq("08100")
+      expect(subject.admin_contacts[0].state).to eq(nil)
+      expect(subject.admin_contacts[0].country).to eq("Finland")
+      expect(subject.admin_contacts[0].country_code).to eq(nil)
+      expect(subject.admin_contacts[0].phone).to eq("+358.503716096")
+      expect(subject.admin_contacts[0].fax).to eq(nil)
+      expect(subject.admin_contacts[0].email).to eq("")
+      expect(subject.admin_contacts[0].created_on).to eq(nil)
+      expect(subject.admin_contacts[0].updated_on).to eq(nil)
     end
   end
   describe "#technical_contacts" do
     it do
-      expect { subject.technical_contacts }.to raise_error(Whois::AttributeNotSupported)
+      expect(subject.technical_contacts).to be_a(Array)
+      expect(subject.technical_contacts.size).to eq(1)
+      expect(subject.technical_contacts[0]).to be_a(Whois::Parser::Contact)
+      expect(subject.technical_contacts[0].type).to eq(Whois::Parser::Contact::TYPE_TECHNICAL)
+      expect(subject.technical_contacts[0].id).to eq(nil)
+      expect(subject.technical_contacts[0].name).to eq("Seravo Oy")
+      expect(subject.technical_contacts[0].address).to eq(nil)
+      expect(subject.technical_contacts[0].city).to eq(nil)
+      expect(subject.technical_contacts[0].zip).to eq(nil)
+      expect(subject.technical_contacts[0].state).to eq(nil)
+      expect(subject.technical_contacts[0].country).to eq(nil)
+      expect(subject.technical_contacts[0].country_code).to eq(nil)
+      expect(subject.technical_contacts[0].phone).to eq(nil)
+      expect(subject.technical_contacts[0].fax).to eq(nil)
+      expect(subject.technical_contacts[0].email).to eq("hostmaster@seravo.com")
+      expect(subject.technical_contacts[0].created_on).to eq(nil)
+      expect(subject.technical_contacts[0].updated_on).to eq(nil)
     end
   end
   describe "#nameservers" do
     it do
       expect(subject.nameservers).to be_a(Array)
-      expect(subject.nameservers.size).to eq(2)
+      expect(subject.nameservers.size).to eq(3)
       expect(subject.nameservers[0]).to be_a(Whois::Parser::Nameserver)
-      expect(subject.nameservers[0].name).to eq("a.ns.netim.net")
+      expect(subject.nameservers[0].name).to eq("ns-184-c.gandi.net")
       expect(subject.nameservers[1]).to be_a(Whois::Parser::Nameserver)
-      expect(subject.nameservers[1].name).to eq("b.ns.netim.net")
+      expect(subject.nameservers[1].name).to eq("ns-196-a.gandi.net")
+      expect(subject.nameservers[2]).to be_a(Whois::Parser::Nameserver)
+      expect(subject.nameservers[2].name).to eq("ns-73-b.gandi.net")
     end
   end
 end

--- a/spec/whois/parsers/responses/whois.fi/fi/status_available_spec.rb
+++ b/spec/whois/parsers/responses/whois.fi/fi/status_available_spec.rb
@@ -23,7 +23,7 @@ describe Whois::Parsers::WhoisFi, "status_available.expected" do
 
   describe "#disclaimer" do
     it do
-      expect(subject.disclaimer).to eq("More information is available at https://domain.fi/\nCopyright (c) Finnish Communications Regulatory Authority")
+      expect(subject.disclaimer).to eq("Copyright (c) Finnish Transport and Communications Agency Traficom")
     end
   end
   describe "#domain" do
@@ -68,23 +68,24 @@ describe Whois::Parsers::WhoisFi, "status_available.expected" do
   end
   describe "#registrar" do
     it do
-      expect { subject.registrar }.to raise_error(Whois::AttributeNotSupported)
+      expect(subject.registrar).to eq(nil)
     end
   end
   describe "#registrant_contacts" do
     it do
-      expect(subject.registrant_contacts).to be_a(Array)
-      expect(subject.registrant_contacts).to eq([])
+      expect { subject.registrant_contacts }.to raise_error(Whois::AttributeNotSupported)
     end
   end
   describe "#admin_contacts" do
     it do
-      expect { subject.admin_contacts }.to raise_error(Whois::AttributeNotSupported)
+      expect(subject.admin_contacts).to be_a(Array)
+      expect(subject.admin_contacts).to eq([])
     end
   end
   describe "#technical_contacts" do
     it do
-      expect { subject.technical_contacts }.to raise_error(Whois::AttributeNotSupported)
+      expect(subject.technical_contacts).to be_a(Array)
+      expect(subject.technical_contacts).to eq([])
     end
   end
   describe "#nameservers" do

--- a/spec/whois/parsers/responses/whois.fi/fi/status_registered_spec.rb
+++ b/spec/whois/parsers/responses/whois.fi/fi/status_registered_spec.rb
@@ -23,7 +23,7 @@ describe Whois::Parsers::WhoisFi, "status_registered.expected" do
 
   describe "#disclaimer" do
     it do
-      expect(subject.disclaimer).to eq("More information is available at https://domain.fi/\nCopyright (c) Finnish Communications Regulatory Authority")
+      expect(subject.disclaimer).to eq("Copyright (c) Finnish Transport and Communications Agency Traficom")
     end
   end
   describe "#domain" do
@@ -60,50 +60,70 @@ describe Whois::Parsers::WhoisFi, "status_registered.expected" do
   describe "#updated_on" do
     it do
       expect(subject.updated_on).to be_a(Time)
-      expect(subject.updated_on).to eq(Time.parse("2013-06-07"))
+      expect(subject.updated_on).to eq(Time.parse("2019-06-02"))
     end
   end
   describe "#expires_on" do
     it do
       expect(subject.expires_on).to be_a(Time)
-      expect(subject.expires_on).to eq(Time.parse("2014-07-04"))
+      expect(subject.expires_on).to eq(Time.parse("2020-07-04 10:15:55"))
     end
   end
   describe "#registrar" do
     it do
-      expect { subject.registrar }.to raise_error(Whois::AttributeNotSupported)
+      expect(subject.registrar.id).to eq(nil)
+      expect(subject.registrar.name).to eq("MarkMonitor Inc.")
+      expect(subject.registrar.organization).to eq("MarkMonitor Inc.")
+      expect(subject.registrar.url).to eq("www.markmonitor.com")
     end
   end
   describe "#registrant_contacts" do
     it do
-      expect(subject.registrant_contacts).to be_a(Array)
-      expect(subject.registrant_contacts.size).to eq(1)
-      expect(subject.registrant_contacts[0]).to be_a(Whois::Parser::Contact)
-      expect(subject.registrant_contacts[0].type).to eq(Whois::Parser::Contact::TYPE_REGISTRANT)
-      expect(subject.registrant_contacts[0].id).to eq("09073468")
-      expect(subject.registrant_contacts[0].name).to eq("Domain Administrator")
-      expect(subject.registrant_contacts[0].organization).to eq("Google Finland Oy")
-      expect(subject.registrant_contacts[0].address).to eq("Mannerheimintie 12 B")
-      expect(subject.registrant_contacts[0].city).to eq("HELSINKI")
-      expect(subject.registrant_contacts[0].zip).to eq("00100")
-      expect(subject.registrant_contacts[0].state).to eq(nil)
-      expect(subject.registrant_contacts[0].country).to eq(nil)
-      expect(subject.registrant_contacts[0].country_code).to eq(nil)
-      expect(subject.registrant_contacts[0].phone).to eq("35896966890")
-      expect(subject.registrant_contacts[0].fax).to eq(nil)
-      expect(subject.registrant_contacts[0].email).to eq(nil)
-      expect(subject.registrant_contacts[0].created_on).to eq(nil)
-      expect(subject.registrant_contacts[0].updated_on).to eq(nil)
+      expect { subject.registrant_contacts }.to raise_error(Whois::AttributeNotSupported)
     end
   end
   describe "#admin_contacts" do
     it do
-      expect { subject.admin_contacts }.to raise_error(Whois::AttributeNotSupported)
+      expect(subject.admin_contacts).to be_a(Array)
+      expect(subject.admin_contacts.size).to eq(1)
+      expect(subject.admin_contacts[0]).to be_a(Whois::Parser::Contact)
+      expect(subject.admin_contacts[0].type).to eq(Whois::Parser::Contact::TYPE_ADMINISTRATIVE)
+      expect(subject.admin_contacts[0].id).to eq("3582691")
+      expect(subject.admin_contacts[0].name).to eq("Google LLC")
+      expect(subject.admin_contacts[0].organization).to eq(nil)
+      expect(subject.admin_contacts[0].address).to eq("1600 Amphitheatre Parkway")
+      expect(subject.admin_contacts[0].zip).to eq("94043")
+      expect(subject.admin_contacts[0].city).to eq("Mountain View")
+      expect(subject.admin_contacts[0].state).to eq(nil)
+      expect(subject.admin_contacts[0].country).to eq("United States of America")
+      expect(subject.admin_contacts[0].country_code).to eq(nil)
+      expect(subject.admin_contacts[0].phone).to eq("+1.6502530000")
+      expect(subject.admin_contacts[0].fax).to eq(nil)
+      expect(subject.admin_contacts[0].email).to eq("")
+      expect(subject.admin_contacts[0].created_on).to eq(nil)
+      expect(subject.admin_contacts[0].updated_on).to eq(nil)
     end
   end
   describe "#technical_contacts" do
     it do
-      expect { subject.technical_contacts }.to raise_error(Whois::AttributeNotSupported)
+      expect(subject.technical_contacts).to be_a(Array)
+      expect(subject.technical_contacts.size).to eq(1)
+      expect(subject.technical_contacts[0]).to be_a(Whois::Parser::Contact)
+      expect(subject.technical_contacts[0].type).to eq(Whois::Parser::Contact::TYPE_TECHNICAL)
+      expect(subject.technical_contacts[0].id).to eq(nil)
+      expect(subject.technical_contacts[0].name).to eq("Google LLC")
+      expect(subject.technical_contacts[0].organization).to eq(nil)
+      expect(subject.technical_contacts[0].address).to eq(nil)
+      expect(subject.technical_contacts[0].city).to eq(nil)
+      expect(subject.technical_contacts[0].zip).to eq(nil)
+      expect(subject.technical_contacts[0].state).to eq(nil)
+      expect(subject.technical_contacts[0].country).to eq(nil)
+      expect(subject.technical_contacts[0].country_code).to eq(nil)
+      expect(subject.technical_contacts[0].phone).to eq(nil)
+      expect(subject.technical_contacts[0].fax).to eq(nil)
+      expect(subject.technical_contacts[0].email).to eq("ccops@markmonitor.com")
+      expect(subject.technical_contacts[0].created_on).to eq(nil)
+      expect(subject.technical_contacts[0].updated_on).to eq(nil)
     end
   end
   describe "#nameservers" do
@@ -111,13 +131,13 @@ describe Whois::Parsers::WhoisFi, "status_registered.expected" do
       expect(subject.nameservers).to be_a(Array)
       expect(subject.nameservers.size).to eq(4)
       expect(subject.nameservers[0]).to be_a(Whois::Parser::Nameserver)
-      expect(subject.nameservers[0].name).to eq("ns1.google.com")
+      expect(subject.nameservers[0].name).to eq("ns3.google.com")
       expect(subject.nameservers[1]).to be_a(Whois::Parser::Nameserver)
-      expect(subject.nameservers[1].name).to eq("ns2.google.com")
+      expect(subject.nameservers[1].name).to eq("ns4.google.com")
       expect(subject.nameservers[2]).to be_a(Whois::Parser::Nameserver)
-      expect(subject.nameservers[2].name).to eq("ns3.google.com")
+      expect(subject.nameservers[2].name).to eq("ns1.google.com")
       expect(subject.nameservers[3]).to be_a(Whois::Parser::Nameserver)
-      expect(subject.nameservers[3].name).to eq("ns4.google.com")
+      expect(subject.nameservers[3].name).to eq("ns2.google.com")
     end
   end
 end

--- a/spec/whois/parsers/responses/whois.fi/fi/status_reserved_spec.rb
+++ b/spec/whois/parsers/responses/whois.fi/fi/status_reserved_spec.rb
@@ -23,7 +23,7 @@ describe Whois::Parsers::WhoisFi, "status_reserved.expected" do
 
   describe "#disclaimer" do
     it do
-      expect(subject.disclaimer).to eq("More information is available at https://domain.fi/\nCopyright (c) Finnish Communications Regulatory Authority")
+      expect(subject.disclaimer).to eq("Copyright (c) Finnish Transport and Communications Agency Traficom")
     end
   end
   describe "#domain" do
@@ -68,23 +68,24 @@ describe Whois::Parsers::WhoisFi, "status_reserved.expected" do
   end
   describe "#registrar" do
     it do
-      expect { subject.registrar }.to raise_error(Whois::AttributeNotSupported)
+      expect(subject.registrar).to eq(nil)
     end
   end
   describe "#registrant_contacts" do
     it do
-      expect(subject.registrant_contacts).to be_a(Array)
-      expect(subject.registrant_contacts).to eq([])
+      expect { subject.registrant_contacts }.to raise_error(Whois::AttributeNotSupported)
     end
   end
   describe "#admin_contacts" do
     it do
-      expect { subject.admin_contacts }.to raise_error(Whois::AttributeNotSupported)
+      expect(subject.admin_contacts).to be_a(Array)
+      expect(subject.admin_contacts).to eq([])
     end
   end
   describe "#technical_contacts" do
     it do
-      expect { subject.technical_contacts }.to raise_error(Whois::AttributeNotSupported)
+      expect(subject.technical_contacts).to be_a(Array)
+      expect(subject.technical_contacts).to eq([])
     end
   end
   describe "#nameservers" do


### PR DESCRIPTION
The whole response format was changed in 2016, this PR changes the tests,
the scanner and the parser in order to respond to the change.