### PR TITLE
Update in.ua parser + update specs

### DIFF
--- a/lib/whois/parsers/whois.in.ua.rb
+++ b/lib/whois/parsers/whois.in.ua.rb
@@ -38,7 +38,7 @@ module Whois
       end
 
       property_supported :available? do
-        !!(content_for_scanner =~ /No records found for object/)
+        !!(content_for_scanner =~ /Domain name does not exist/)
       end
 
       property_supported :registered? do
@@ -46,19 +46,21 @@ module Whois
       end
 
 
-      property_not_supported :created_on
+      property_supported :created_on do
+        if content_for_scanner =~ /created:\s+(.*)\n/
+          parse_time($1)
+        end
+      end
 
       property_supported :updated_on do
-        if content_for_scanner =~ /changed:\s+(.*)\n/
-          time = $1.split(" ").last
-          Time.strptime(time, "%Y%m%d%H%M%S")
+        if content_for_scanner =~ /modified:\s+(.*)\n/
+          parse_time($1)
         end
       end
 
       property_supported :expires_on do
-        if content_for_scanner =~ /status:\s+(.*)\n/
-          time = $1.split(" ").last
-          Time.strptime(time, "%Y%m%d%H%M%S")
+        if content_for_scanner =~ /expires:\s+(.*)\n/
+          parse_time($1)
         end
       end
 

--- a/spec/fixtures/responses/whois.in.ua/in.ua/status_available.expected
+++ b/spec/fixtures/responses/whois.in.ua/in.ua/status_available.expected
@@ -9,7 +9,7 @@
 
 
 #created_on
-  %s %ERROR{AttributeNotSupported}
+  %s == nil
 
 #updated_on
   %s == nil

--- a/spec/fixtures/responses/whois.in.ua/in.ua/status_available.txt
+++ b/spec/fixtures/responses/whois.in.ua/in.ua/status_available.txt
@@ -1,4 +1,12 @@
-% In.UA whois server. (whois.in.ua)
-% All questions regarding this service please send to help@whois.in.ua
-% To search for domains and In.UA maintainers using the web, visit http://whois.in.ua
-% No records found for object U34JEDZCQ.IN.UA
+% This is the SUNIC WHOIS server.
+% The Whois is subject to Terms of use
+% See https://hostmaster.ua/documents.php
+%
+% In the process of delegation of a domain name,
+% the Registrant is an entity who uses and manages a certain domain name,
+% and the Registrar is a business entity that provides the Registrant
+% with the services necessary for the technical maintenance of the
+% registration and operation of the domain name.
+% For information on the Registrant's domain name, you should contact the Registrar.
+
+u34jedzcq.in.ua - Domain name does not exist

--- a/spec/fixtures/responses/whois.in.ua/in.ua/status_registered.expected
+++ b/spec/fixtures/responses/whois.in.ua/in.ua/status_registered.expected
@@ -9,23 +9,24 @@
 
 
 #created_on
-  %s %ERROR{AttributeNotSupported}
+  %s %CLASS{time}
+  %s %TIME{2007-12-18 20:12:35 +02:00}
 
 #updated_on
   %s %CLASS{time}
-  %s %TIME{2012-12-16 13:41:04}
+  %s %TIME{2019-12-03 11:15:10 +02:00}
 
 #expires_on
   %s %CLASS{time}
-  %s %TIME{2013-12-18 00:00:00}
+  %s %TIME{2020-12-20 00:00:00 +02:00}
 
 
 #nameservers
   %s %CLASS{array}
   %s %SIZE{3}
   %s[0] %CLASS{nameserver}
-  %s[0].name == "ns12.uadns.com"
+  %s[0].name == "ns10.uadns.com"
   %s[1] %CLASS{nameserver}
-  %s[1].name == "ns11.uadns.com"
+  %s[1].name == "ns12.uadns.com"
   %s[2] %CLASS{nameserver}
-  %s[2].name == "ns10.uadns.com"
+  %s[2].name == "ns11.uadns.com"

--- a/spec/fixtures/responses/whois.in.ua/in.ua/status_registered.txt
+++ b/spec/fixtures/responses/whois.in.ua/in.ua/status_registered.txt
@@ -1,16 +1,92 @@
-% In.UA whois server. (whois.in.ua)
-% All questions regarding this service please send to help@whois.in.ua
-% To search for domains and In.UA maintainers using the web, visit http://whois.in.ua
-domain:      dle.in.ua
-descr:       dle.in.ua
-admin-c:     VP535-UANIC
-tech-c:      NIC-UANIC
-status:      OK-UNTIL 20131218000000
-nserver:     NS12.UADNS.COM 
-nserver:     NS11.UADNS.COM 
-nserver:     NS10.UADNS.COM 
-mnt-by:      DRS-MNT-INUA
-mnt-lower:   DRS-MNT-INUA
-changed:     notify@drs.ua 20121216134104
-source:      INUA
+% This is the SUNIC WHOIS server.
+% The Whois is subject to Terms of use
+% See https://hostmaster.ua/documents.php
+%
+% In the process of delegation of a domain name,
+% the Registrant is an entity who uses and manages a certain domain name,
+% and the Registrar is a business entity that provides the Registrant
+% with the services necessary for the technical maintenance of the
+% registration and operation of the domain name.
+% For information on the Registrant's domain name, you should contact the Registrar.
+
+domain:             dle.in.ua
+dom-public:         NO
+mnt-by:             ua.nic
+nserver:            ns10.uadns.com
+nserver:            ns12.uadns.com
+nserver:            ns11.uadns.com
+status:             ok
+created:            2007-12-18 20:12:35+02
+modified:           2019-12-03 11:15:10+02
+expires:            2020-12-20 00:00:00+02
+source:             SUNIC
+
+% Registrar:
+% ==========
+registrar:          ua.nic
+organization:       NIC.UA LLC
+organization-loc:   ТОВ «НІК.ЮЕЙ»
+url:                http://nic.ua
+city:               Dnipro
+country:            UA
+abuse-email:        abuse@nic.ua
+abuse-phone:        +380.445933222
+abuse-postal:       Ukraine 49000 Dnipro PO/BOX 80
+abuse-postal-loc:   UA 49000 Днепр а/я 80
+source:             SUNIC
+
+% Registrant:
+% ===========
+person:             n/a
+organization:       n/a
+address:            n/a
+person-loc:         not published
+organization-loc:   not published
+address-loc:        not published
+email:              not published
+phone:              not published
+fax:                not published
+mnt-by:             sunic
+status:             linked
+status:             ok
+created:            2017-09-30 01:31:30+03
+modified:           2017-09-30 01:31:30+03
+source:             SUNIC
+
+% Administrative Contacts:
+% ========================
+person:             n/a
+organization:       n/a
+address:            n/a
+person-loc:         not published
+organization-loc:   not published
+address-loc:        not published
+email:              not published
+phone:              not published
+fax:                not published
+mnt-by:             sunic
+status:             linked
+status:             ok
+created:            2017-09-30 01:31:30+03
+modified:           2017-09-30 01:31:30+03
+source:             SUNIC
+
+
+% Technical Contacts:
+% ===================
+person:             NIC-UANIC
+organization:       NIC.UA LLC
+address:            not published
+person-loc:         n/a
+organization-loc:   n/a
+address-loc:        n/a
+email:              support@nic.ua
+phone:              +380.445933222
+fax:                +380.445937569
+mnt-by:             sunic
+status:             linked
+status:             ok
+created:            2016-09-18 10:37:53+03
+modified:           2016-09-17 10:37:53+03
+source:             SUNIC
 

--- a/spec/whois/parsers/responses/whois.in.ua/in.ua/status_available_spec.rb
+++ b/spec/whois/parsers/responses/whois.in.ua/in.ua/status_available_spec.rb
@@ -38,7 +38,7 @@ describe Whois::Parsers::WhoisInUa, "status_available.expected" do
   end
   describe "#created_on" do
     it do
-      expect { subject.created_on }.to raise_error(Whois::AttributeNotSupported)
+      expect(subject.created_on).to eq(nil)
     end
   end
   describe "#updated_on" do

--- a/spec/whois/parsers/responses/whois.in.ua/in.ua/status_registered_spec.rb
+++ b/spec/whois/parsers/responses/whois.in.ua/in.ua/status_registered_spec.rb
@@ -38,19 +38,20 @@ describe Whois::Parsers::WhoisInUa, "status_registered.expected" do
   end
   describe "#created_on" do
     it do
-      expect { subject.created_on }.to raise_error(Whois::AttributeNotSupported)
+      expect(subject.created_on).to be_a(Time)
+      expect(subject.created_on).to eq(Time.parse("2007-12-18 20:12:35 +02:00"))
     end
   end
   describe "#updated_on" do
     it do
       expect(subject.updated_on).to be_a(Time)
-      expect(subject.updated_on).to eq(Time.parse("2012-12-16 13:41:04"))
+      expect(subject.updated_on).to eq(Time.parse("2019-12-03 11:15:10 +02:00"))
     end
   end
   describe "#expires_on" do
     it do
       expect(subject.expires_on).to be_a(Time)
-      expect(subject.expires_on).to eq(Time.parse("2013-12-18 00:00:00"))
+      expect(subject.expires_on).to eq(Time.parse("2020-12-20 00:00:00 +02:00"))
     end
   end
   describe "#nameservers" do
@@ -58,11 +59,11 @@ describe Whois::Parsers::WhoisInUa, "status_registered.expected" do
       expect(subject.nameservers).to be_a(Array)
       expect(subject.nameservers.size).to eq(3)
       expect(subject.nameservers[0]).to be_a(Whois::Parser::Nameserver)
-      expect(subject.nameservers[0].name).to eq("ns12.uadns.com")
+      expect(subject.nameservers[0].name).to eq("ns10.uadns.com")
       expect(subject.nameservers[1]).to be_a(Whois::Parser::Nameserver)
-      expect(subject.nameservers[1].name).to eq("ns11.uadns.com")
+      expect(subject.nameservers[1].name).to eq("ns12.uadns.com")
       expect(subject.nameservers[2]).to be_a(Whois::Parser::Nameserver)
-      expect(subject.nameservers[2].name).to eq("ns10.uadns.com")
+      expect(subject.nameservers[2].name).to eq("ns11.uadns.com")
     end
   end
 end


### PR DESCRIPTION
Based on the work made by @Vanav in #69, here is a new PR that takes the latest version of the SUNIC WHOIS reply (yes it changed again), simplifies a bit the time parsing code to use `parse_time`, and update the specs with accurate new values, including time zone.

I also verified this code with a couple other in.ua hostnames I have and it worked fine with them.
Let me know if there's anything that could be done better.

PS: I'm starting to use whois-parser for [my service](https://updown.io) to notify about domain expiration (and maybe more later). So I have a lot of data about domains and TLD for which the parser is working or not (or has outdated definitions) and am ready to provide some (a lot of?) contributions if you are open. I just thought I would ask you first, not to spend too much time on this if you're not interested in them, let me know!

![image](https://user-images.githubusercontent.com/201687/95771693-c8126b00-0cbb-11eb-8eb8-3b059d76d27f.png)

Thanks for this great work !
If this gets merged we can close #69 